### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A Model Context Protocol (MCP) server for interacting with Twitter (X) via AI tools. This server allows you to fetch tweets, post tweets, search Twitter, manage followers, and more, all through natural language commands in AI Tools.
 
+<a href="https://glama.ai/mcp/servers/@rafaljanicki/x-twitter-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@rafaljanicki/x-twitter-mcp-server/badge" alt="X (Twitter) server MCP server" />
+</a>
+
 ## Features
 
 - Fetch user profiles, followers, and following lists.


### PR DESCRIPTION
This PR adds a badge for the [X (Twitter) MCP server](https://glama.ai/mcp/servers/@rafaljanicki/x-twitter-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@rafaljanicki/x-twitter-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@rafaljanicki/x-twitter-mcp-server/badge" alt="X (Twitter) server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.