### PR TITLE
fix: handle dict response from create_tweet

### DIFF
--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -215,7 +215,7 @@ async def post_tweet(text: str, media_paths: Optional[List[str]] = None, reply_t
     logger.info(f"Type of response from client.create_tweet: {type(tweet)}; Content: {tweet}")
     if not tweet.data:
         return None
-    return tweet.data if isinstance(tweet.data, dict) else tweet.data.data
+    return tweet.data
 
 @server.tool(name="delete_tweet", description="Delete a tweet by its ID")
 async def delete_tweet(tweet_id: str) -> Dict:
@@ -261,7 +261,7 @@ async def create_poll_tweet(text: str, choices: List[str], duration_minutes: int
     tweet = client.create_tweet(**poll_data)
     if not tweet.data:
         return None
-    return tweet.data if isinstance(tweet.data, dict) else tweet.data.data
+    return tweet.data
 
 @server.tool(name="vote_on_poll", description="Vote on a poll (mocked)")
 async def vote_on_poll(tweet_id: str, choice: str) -> Dict:

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -213,7 +213,9 @@ async def post_tweet(text: str, media_paths: Optional[List[str]] = None, reply_t
         tweet_data["media_ids"] = media_ids
     tweet = client.create_tweet(**tweet_data)
     logger.info(f"Type of response from client.create_tweet: {type(tweet)}; Content: {tweet}")
-    return tweet.data.data if tweet.data else None
+    if not tweet.data:
+        return None
+    return tweet.data if isinstance(tweet.data, dict) else tweet.data.data
 
 @server.tool(name="delete_tweet", description="Delete a tweet by its ID")
 async def delete_tweet(tweet_id: str) -> Dict:
@@ -257,7 +259,9 @@ async def create_poll_tweet(text: str, choices: List[str], duration_minutes: int
         "poll_duration_minutes": duration_minutes
     }
     tweet = client.create_tweet(**poll_data)
-    return tweet.data.data if tweet.data else None
+    if not tweet.data:
+        return None
+    return tweet.data if isinstance(tweet.data, dict) else tweet.data.data
 
 @server.tool(name="vote_on_poll", description="Vote on a poll (mocked)")
 async def vote_on_poll(tweet_id: str, choice: str) -> Dict:


### PR DESCRIPTION
## Summary

Fix `post_tweet` and `create_poll_tweet` failing with `'dict' object has no attribute 'data'` error.

## Problem

`client.create_tweet()` returns a Response where `.data` is already a `dict`, not a model object. The current code tries to access `.data.data` which fails.

## Solution

Add `isinstance` check to handle both dict and model object responses:

```python
if not tweet.data:
    return None
return tweet.data if isinstance(tweet.data, dict) else tweet.data.data
```

Fixes #7