### PR TITLE
feat: add get_bookmarks tool with OAuth 2.0 User Context support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ TWITTER_API_SECRET="YOUR_API_SECRET"
 TWITTER_ACCESS_TOKEN="YOUR_ACCESS_TOKEN"
 TWITTER_ACCESS_TOKEN_SECRET="YOUR_ACCESS_TOKEN_SECRET"
 TWITTER_BEARER_TOKEN="YOUR_BEARER_TOKEN"
+# Required for bookmark operations (get_bookmarks, delete_all_bookmarks).
+# Obtain via the PKCE authorization flow using tweepy.OAuth2UserHandler
+# with bookmark.read, bookmark.write, and users.read scopes.
+TWITTER_OAUTH2_USER_ACCESS_TOKEN="YOUR_OAUTH2_USER_ACCESS_TOKEN"

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ uv run x-twitter-mcp-server
 To use this MCP server with Claude Desktop, you need to configure Claude to connect to the server. Follow these steps:
 
 ### Step 1: Install Node.js
-Claude Desktop uses Node.js to run MCP servers. If you don’t have Node.js installed:
+Claude Desktop uses Node.js to run MCP servers. If you don't have Node.js installed:
 - Download and install Node.js from [nodejs.org](https://nodejs.org/).
 - Verify installation:
   ```bash
@@ -164,7 +164,7 @@ Claude Desktop uses a `claude_desktop_config.json` file to configure MCP servers
 - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 
-If the file doesn’t exist, create it.
+If the file doesn't exist, create it.
 
 ### Step 3: Configure the MCP Server
 Edit `claude_desktop_config.json` to include the `x-twitter-mcp` server. Replace `/path/to/x-twitter-mcp-server` with the actual path to your project directory (if installed from source) or the path to your Python executable (if installed from PyPI).
@@ -210,7 +210,7 @@ If installed from source with `uv`:
 ```
 
 - `"command": "x-twitter-mcp-server"`: Uses the CLI script directly if installed from PyPI.
-- `"env"`: If installed from PyPI, you may need to provide environment variables directly in the config (since there’s no `.env` file). If installed from source, the `.env` file will be used.
+- `"env"`: If installed from PyPI, you may need to provide environment variables directly in the config (since there's no `.env` file). If installed from source, the `.env` file will be used.
 - `"env": {"PYTHONUNBUFFERED": "1"}`: Ensures output is unbuffered for better logging in Claude.
 
 ### Step 4: Restart Claude Desktop
@@ -229,7 +229,7 @@ You can now interact with Twitter using natural language in Claude Desktop. Here
   ```
   Get the Twitter profile for user ID 123456.
   ```
-  Claude will call the `get_user_profile` tool and return the user’s details.
+  Claude will call the `get_user_profile` tool and return the user's details.
 
 - **Post a Tweet**:
   ```
@@ -263,7 +263,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   ```
   Get the Twitter profile for user ID 123456789.
   ```
-  Claude will return the user’s profile details, including ID, name, username, profile image URL, and description.
+  Claude will return the user's profile details, including ID, name, username, profile image URL, and description.
 
 #### `get_user_by_screen_name`
 - **Description**: Fetches a user by screen name.
@@ -271,7 +271,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   ```
   Get the Twitter user with screen name "example_user".
   ```
-  Claude will return the user’s profile details.
+  Claude will return the user's profile details.
 
 #### `get_user_by_id`
 - **Description**: Fetches a user by ID.
@@ -279,7 +279,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   ```
   Fetch the Twitter user with ID 987654321.
   ```
-  Claude will return the user’s profile details.
+  Claude will return the user's profile details.
 
 #### `get_user_followers`
 - **Description**: Retrieves a list of followers for a given user.
@@ -337,7 +337,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   ```
   Get details for tweet ID 123456789012345678.
   ```
-  Claude will return the tweet’s details, including ID, text, creation date, and author ID.
+  Claude will return the tweet's details, including ID, text, creation date, and author ID.
 
 #### `create_poll_tweet`
 - **Description**: Create a tweet with a poll.
@@ -353,7 +353,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   ```
   Vote "Blue" on the poll in tweet ID 123456789012345678.
   ```
-  Claude will return a mock response (since Twitter API v2 doesn’t support poll voting).
+  Claude will return a mock response (since Twitter API v2 doesn't support poll voting).
 
 #### `favorite_tweet`
 - **Description**: Favorites a tweet.
@@ -395,6 +395,14 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   ```
   Claude will delete all bookmarks and confirm the action.
 
+#### `get_bookmarks`
+- **Description**: Retrieves the authenticated user's bookmarked tweets. Requires Basic access tier or higher.
+- **Claude Desktop Example**:
+  ```
+  Show my Twitter bookmarks, limit to 25.
+  ```
+  Claude will return up to 25 bookmarked tweets, including ID, text, creation date, and author ID.
+
 ### Timeline & Search Tools
 
 #### `get_timeline`
@@ -430,12 +438,12 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   Claude will return up to 10 trending topics.
 
 #### `get_highlights_tweets`
-- **Description**: Retrieves highlighted tweets from a user’s timeline.
+- **Description**: Retrieves highlighted tweets from a user's timeline.
 - **Claude Desktop Example**:
   ```
   Get highlighted tweets from user ID 123456789, limit to 20.
   ```
-  Claude will return up to 20 tweets from the user’s timeline (simulated as highlights).
+  Claude will return up to 20 tweets from the user's timeline (simulated as highlights).
 
 #### `get_user_mentions`
 - **Description**: Get tweets mentioning a specific user.
@@ -457,7 +465,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
     - Confirm the path in `claude_desktop_config.json` is correct.
     - Ensure the `command` and `args` point to the correct executable and script.
     - Restart Claude Desktop after updating the config file.
-    - Check Claude’s Developer Mode logs (Help → Enable Developer Mode → Open MCP Log File) for errors.
+    - Check Claude's Developer Mode logs (Help → Enable Developer Mode → Open MCP Log File) for errors.
 
 - **Rate Limit Errors**:
     - The server includes rate limit handling, but if you hit Twitter API limits, you may need to wait for the reset window (e.g., 15 minutes for tweet actions).

--- a/README.md
+++ b/README.md
@@ -423,15 +423,15 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   Claude will remove the bookmark and confirm the action.
 
 #### `delete_all_bookmarks`
-- **Description**: Deletes all bookmarks (simulated by fetching and removing one by one). Requires `TWITTER_OAUTH2_USER_ACCESS_TOKEN`.
+- **Description**: DESTRUCTIVE AND IRREVERSIBLE. Permanently deletes ALL bookmarks by fetching every page and removing them one by one. Requires `TWITTER_OAUTH2_USER_ACCESS_TOKEN`.
 - **Claude Desktop Example**:
   ```
   Delete all my Twitter bookmarks.
   ```
-  Claude will delete all bookmarks and confirm the action.
+  Claude will confirm with the user first, then delete all bookmarks and report the count.
 
 #### `get_bookmarks`
-- **Description**: Retrieves the authenticated user's bookmarked tweets (up to 800 most recent). Requires `TWITTER_OAUTH2_USER_ACCESS_TOKEN`.
+- **Description**: Retrieves the authenticated user's bookmarked tweets. Returns up to 100 tweets per call; use the `cursor` parameter for pagination. Requires `TWITTER_OAUTH2_USER_ACCESS_TOKEN`.
 - **Claude Desktop Example**:
   ```
   Show my Twitter bookmarks, limit to 25.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,40 @@ If you prefer to install from the source repository:
       TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret
       TWITTER_BEARER_TOKEN=your_bearer_token
       ```
+    - To use bookmark tools (`get_bookmarks`, `delete_all_bookmarks`), also add an OAuth 2.0 user access token:
+      ```
+      TWITTER_OAUTH2_USER_ACCESS_TOKEN=your_oauth2_user_token
+      ```
+      See [Obtaining an OAuth 2.0 User Token](#obtaining-an-oauth-20-user-token) below.
+
+## Obtaining an OAuth 2.0 User Token
+
+The bookmark endpoints (`GET /2/users/:id/bookmarks`, `DELETE /2/users/:id/bookmarks/:tweet_id`) require **OAuth 2.0 User Context** — they reject both app-only bearer tokens and OAuth 1.0a. You need to perform the PKCE authorization flow once to obtain a user-scoped token.
+
+### Steps
+
+1. In the [Twitter Developer Portal](https://developer.twitter.com/), open your app → **Settings** → **User authentication settings** and enable OAuth 2.0. Set a callback URL (e.g. `https://localhost/`).
+
+2. Run the PKCE flow using Tweepy:
+
+```python
+import tweepy
+
+handler = tweepy.OAuth2UserHandler(
+    client_id="YOUR_CLIENT_ID",       # OAuth 2.0 Client ID (from Developer Portal)
+    redirect_uri="https://localhost/",
+    scope=["bookmark.read", "bookmark.write", "users.read", "offline.access"],
+    client_secret="YOUR_CLIENT_SECRET",  # Optional for public clients
+)
+
+print(handler.get_authorization_url())
+# Open the URL, authorize, copy the redirected URL, then:
+redirected_url = input("Paste redirected URL: ")
+token = handler.fetch_token(redirected_url)
+print(token["access_token"])
+```
+
+3. Set the resulting token as `TWITTER_OAUTH2_USER_ACCESS_TOKEN` in your environment or `.env` file.
 
 ## Running the Server
 
@@ -182,7 +216,8 @@ If installed from PyPI:
         "TWITTER_API_SECRET": "your_api_secret",
         "TWITTER_ACCESS_TOKEN": "your_access_token",
         "TWITTER_ACCESS_TOKEN_SECRET": "your_access_token_secret",
-        "TWITTER_BEARER_TOKEN": "your_bearer_token"
+        "TWITTER_BEARER_TOKEN": "your_bearer_token",
+        "TWITTER_OAUTH2_USER_ACCESS_TOKEN": "your_oauth2_user_token"
       }
     }
   }
@@ -388,7 +423,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   Claude will remove the bookmark and confirm the action.
 
 #### `delete_all_bookmarks`
-- **Description**: Deletes all bookmarks.
+- **Description**: Deletes all bookmarks (simulated by fetching and removing one by one). Requires `TWITTER_OAUTH2_USER_ACCESS_TOKEN`.
 - **Claude Desktop Example**:
   ```
   Delete all my Twitter bookmarks.
@@ -396,7 +431,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   Claude will delete all bookmarks and confirm the action.
 
 #### `get_bookmarks`
-- **Description**: Retrieves the authenticated user's bookmarked tweets. Requires Basic access tier or higher.
+- **Description**: Retrieves the authenticated user's bookmarked tweets (up to 800 most recent). Requires `TWITTER_OAUTH2_USER_ACCESS_TOKEN`.
 - **Claude Desktop Example**:
   ```
   Show my Twitter bookmarks, limit to 25.
@@ -469,6 +504,10 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
 
 - **Rate Limit Errors**:
     - The server includes rate limit handling, but if you hit Twitter API limits, you may need to wait for the reset window (e.g., 15 minutes for tweet actions).
+
+- **Bookmark tools return 403**:
+    - `get_bookmarks` and `delete_all_bookmarks` require `TWITTER_OAUTH2_USER_ACCESS_TOKEN`. App-only bearer tokens and OAuth 1.0a are rejected by the bookmarks endpoint.
+    - See [Obtaining an OAuth 2.0 User Token](#obtaining-an-oauth-20-user-token) for setup instructions.
 
 - **Syntax Warnings**:
     - If you see `SyntaxWarning` messages from Tweepy, they are due to docstring issues in Tweepy with Python 3.13. The server includes a warning suppression to handle this.

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -28,6 +28,9 @@ startCommand:
       twitterBearerToken:
         type: string
         description: Twitter Bearer Token
+      twitterOauth2UserAccessToken:
+        type: string
+        description: "OAuth 2.0 user access token (PKCE flow). Required for bookmark operations (get_bookmarks, delete_all_bookmarks). Obtain via tweepy.OAuth2UserHandler with bookmark.read, bookmark.write, and users.read scopes."
   exampleConfig:
     twitterApiKey: ABC123KEY
     twitterApiSecret: DEF456SECRET

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import warnings
+import requests
 from fastmcp import FastMCP
 import tweepy
 from collections import defaultdict
@@ -64,25 +65,40 @@ def initialize_twitter_clients() -> tuple[tweepy.Client, tweepy.API]:
     return _twitter_client, _twitter_v1_api
 
 
-def _make_oauth2_bookmarks_client() -> tweepy.Client:
-    """Return a Tweepy client using the OAuth 2.0 user access token.
+def _bookmarks_api(method: str, tweet_id: Optional[str] = None, params: Optional[dict] = None) -> dict:
+    """Make a bookmark API request using OAuth 2.0 User Context.
 
     The bookmarks endpoint (/2/users/:id/bookmarks) requires OAuth 2.0 User
-    Context. It rejects both app-only bearer tokens and OAuth 1.0a. A user
-    OAuth 2.0 token — obtained via the PKCE authorization flow — is passed as
-    the bearer token, which satisfies the requirement.
+    Context — it rejects both app-only bearer tokens and OAuth 1.0a. This
+    function resolves the authenticated user ID via /2/users/me, then calls
+    the bookmarks endpoint with the user-scoped token as a Bearer.
 
-    Set TWITTER_OAUTH2_USER_ACCESS_TOKEN to the token produced by the PKCE
-    flow (tweepy.OAuth2UserHandler).
+    Set TWITTER_OAUTH2_USER_ACCESS_TOKEN to the token obtained via the PKCE
+    authorization flow (tweepy.OAuth2UserHandler) with bookmark.read,
+    bookmark.write, and users.read scopes.
+
+    Args:
+        method: HTTP method ("GET" or "DELETE").
+        tweet_id: Tweet ID appended to the URL for DELETE requests.
+        params: Query parameters for GET requests.
     """
     token = os.getenv("TWITTER_OAUTH2_USER_ACCESS_TOKEN")
     if not token:
         raise EnvironmentError(
             "Missing required environment variable: TWITTER_OAUTH2_USER_ACCESS_TOKEN. "
-            "Obtain one via the PKCE flow (tweepy.OAuth2UserHandler) with "
-            "bookmark.read and users.read scopes."
+            "Obtain one via the PKCE authorization flow (tweepy.OAuth2UserHandler) "
+            "with bookmark.read, bookmark.write, and users.read scopes."
         )
-    return tweepy.Client(bearer_token=token)
+    headers = {"Authorization": f"Bearer {token}"}
+    me = requests.get("https://api.twitter.com/2/users/me", headers=headers)
+    me.raise_for_status()
+    user_id = me.json()["data"]["id"]
+    url = f"https://api.twitter.com/2/users/{user_id}/bookmarks"
+    if tweet_id:
+        url += f"/{tweet_id}"
+    resp = requests.request(method, url, headers=headers, params=params or {})
+    resp.raise_for_status()
+    return resp.json()
 
 
 # Rate limiting configuration
@@ -356,18 +372,11 @@ async def delete_all_bookmarks() -> Dict:
     """Deletes all bookmarks. (Simulated as Twitter API v2 doesn't have a direct endpoint for this. Fetches all bookmarks and deletes them one by one.)"""
     if not check_rate_limit("tweet_actions"):
         raise Exception("Tweet action rate limit exceeded")
-    client, _ = initialize_twitter_clients()
-    # Twitter API v2 doesn't have a direct endpoint; simulate by fetching and removing
-    oauth2_client = _make_oauth2_bookmarks_client()
-    user_id = oauth2_client._get_authenticating_user_id()
-    bookmarks = oauth2_client._make_request(
-        "GET", f"/2/users/{user_id}/bookmarks",
-        params={"max_results": 100},
-        endpoint_parameters=("max_results",),
-        data_type=tweepy.Tweet,
-    )
-    for bookmark in (bookmarks.data or []):
-        client.remove_bookmark(tweet_id=bookmark.id)
+    # Twitter API v2 doesn't have a direct endpoint; simulate by fetching and removing.
+    # Both fetch and delete require OAuth 2.0 User Context.
+    data = _bookmarks_api("GET", params={"max_results": 100})
+    for tweet in data.get("data", []):
+        _bookmarks_api("DELETE", tweet_id=tweet["id"])
     return {"status": "all bookmarks deleted"}
 
 @server.tool(name="get_bookmarks", description="Retrieves the authenticated user's bookmarked tweets. Requires Basic access tier or higher.")
@@ -375,7 +384,7 @@ async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None
     """Fetches the authenticated user's bookmarked tweets.
 
     Requires TWITTER_OAUTH2_USER_ACCESS_TOKEN — a user-scoped OAuth 2.0 token
-    obtained via the PKCE flow with bookmark.read and users.read scopes.
+    obtained via the PKCE authorization flow with bookmark.read and users.read scopes.
 
     Args:
         count (Optional[int]): Number of bookmarks to retrieve. Default 100. Min 1, Max 100.
@@ -391,21 +400,14 @@ async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None
         effective_count = 100
     else:
         effective_count = count
-    oauth2_client = _make_oauth2_bookmarks_client()
-    user_id = oauth2_client._get_authenticating_user_id()
-    bookmarks = oauth2_client._make_request(
-        "GET", f"/2/users/{user_id}/bookmarks",
-        params={
-            "max_results": effective_count,
-            "pagination_token": cursor,
-            "tweet.fields": "id,text,created_at,author_id",
-        },
-        endpoint_parameters=("expansions", "max_results", "media.fields",
-                             "pagination_token", "place.fields", "poll.fields",
-                             "tweet.fields", "user.fields"),
-        data_type=tweepy.Tweet,
-    )
-    return [tweet.data for tweet in (bookmarks.data or [])]
+    params: dict = {
+        "max_results": effective_count,
+        "tweet.fields": "id,text,created_at,author_id",
+    }
+    if cursor:
+        params["pagination_token"] = cursor
+    data = _bookmarks_api("GET", params=params)
+    return data.get("data", [])
 
 # Timeline & Search Tools
 @server.tool(name="get_timeline", description="Get tweets from your home timeline (For You)")

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -90,6 +90,28 @@ def check_rate_limit(action_type: str) -> bool:
     return True
 
 
+def _get_bookmarks_with_user_auth(client: tweepy.Client, max_results: int = 100, pagination_token: Optional[str] = None):
+    """Fetch bookmarks using OAuth 1.0a user context.
+
+    tweepy.Client.get_bookmarks() does not expose a user_auth parameter and
+    always defaults to bearer token auth, which the bookmarks endpoint rejects
+    with 403. This helper calls _make_request() directly with user_auth=True.
+    """
+    user_id = client._get_authenticating_user_id(oauth_1=True)
+    params = {"max_results": max_results, "tweet.fields": "id,text,created_at,author_id"}
+    if pagination_token:
+        params["pagination_token"] = pagination_token
+    return client._make_request(
+        "GET", f"/2/users/{user_id}/bookmarks",
+        params=params,
+        endpoint_parameters=("expansions", "max_results", "media.fields",
+                             "pagination_token", "place.fields", "poll.fields",
+                             "tweet.fields", "user.fields"),
+        data_type=tweepy.Tweet,
+        user_auth=True
+    )
+
+
 # User Management Tools
 @server.tool(name="get_user_profile", description="Get detailed profile information for a user")
 async def get_user_profile(user_id: str) -> Dict:
@@ -336,7 +358,7 @@ async def delete_all_bookmarks() -> Dict:
         raise Exception("Tweet action rate limit exceeded")
     client, _ = initialize_twitter_clients()
     # Twitter API v2 doesn't have a direct endpoint; simulate by fetching and removing
-    bookmarks = client.get_bookmarks(user_auth=True)
+    bookmarks = _get_bookmarks_with_user_auth(client)
     for bookmark in (bookmarks.data or []):
         client.remove_bookmark(tweet_id=bookmark.id)
     return {"status": "all bookmarks deleted"}
@@ -361,12 +383,7 @@ async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None
         effective_count = 100
     else:
         effective_count = count
-    bookmarks = client.get_bookmarks(
-        max_results=effective_count,
-        pagination_token=cursor,
-        tweet_fields=["id", "text", "created_at", "author_id"],
-        user_auth=True
-    )
+    bookmarks = _get_bookmarks_with_user_auth(client, max_results=effective_count, pagination_token=cursor)
     return [tweet.data for tweet in (bookmarks.data or [])]
 
 # Timeline & Search Tools

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -64,23 +64,22 @@ def initialize_twitter_clients() -> tuple[tweepy.Client, tweepy.API]:
 
     return _twitter_client, _twitter_v1_api
 
+_API_TIMEOUT = 30  # seconds
 
-def _bookmarks_api(method: str, tweet_id: Optional[str] = None, params: Optional[dict] = None) -> dict:
-    """Make a bookmark API request using OAuth 2.0 User Context.
+
+def _get_oauth2_headers_and_user_id() -> tuple[dict, str]:
+    """Resolve OAuth 2.0 Authorization headers and the authenticated user ID.
 
     The bookmarks endpoint (/2/users/:id/bookmarks) requires OAuth 2.0 User
-    Context — it rejects both app-only bearer tokens and OAuth 1.0a. This
-    function resolves the authenticated user ID via /2/users/me, then calls
-    the bookmarks endpoint with the user-scoped token as a Bearer.
+    Context — it rejects both app-only bearer tokens and OAuth 1.0a.
 
     Set TWITTER_OAUTH2_USER_ACCESS_TOKEN to the token obtained via the PKCE
     authorization flow (tweepy.OAuth2UserHandler) with bookmark.read,
     bookmark.write, and users.read scopes.
 
-    Args:
-        method: HTTP method ("GET" or "DELETE").
-        tweet_id: Tweet ID appended to the URL for DELETE requests.
-        params: Query parameters for GET requests.
+    Returns:
+        A (headers, user_id) tuple. Call once per operation and reuse across
+        multiple requests to avoid redundant /2/users/me lookups.
     """
     token = os.getenv("TWITTER_OAUTH2_USER_ACCESS_TOKEN")
     if not token:
@@ -90,13 +89,27 @@ def _bookmarks_api(method: str, tweet_id: Optional[str] = None, params: Optional
             "with bookmark.read, bookmark.write, and users.read scopes."
         )
     headers = {"Authorization": f"Bearer {token}"}
-    me = requests.get("https://api.twitter.com/2/users/me", headers=headers)
+    me = requests.get("https://api.twitter.com/2/users/me", headers=headers, timeout=_API_TIMEOUT)
     me.raise_for_status()
-    user_id = me.json()["data"]["id"]
+    return headers, me.json()["data"]["id"]
+
+
+def _bookmarks_request(method: str, headers: dict, user_id: str,
+                       tweet_id: Optional[str] = None,
+                       params: Optional[dict] = None) -> dict:
+    """Make a single bookmark API request.
+
+    Args:
+        method: HTTP method ("GET" or "DELETE").
+        headers: Authorization headers from _get_oauth2_headers_and_user_id().
+        user_id: Authenticated user's ID.
+        tweet_id: Tweet ID appended to the URL for DELETE requests.
+        params: Query parameters for GET requests.
+    """
     url = f"https://api.twitter.com/2/users/{user_id}/bookmarks"
     if tweet_id:
         url += f"/{tweet_id}"
-    resp = requests.request(method, url, headers=headers, params=params or {})
+    resp = requests.request(method, url, headers=headers, params=params or {}, timeout=_API_TIMEOUT)
     resp.raise_for_status()
     return resp.json()
 
@@ -376,27 +389,48 @@ async def delete_all_bookmarks() -> Dict:
     this tool. Do not call this based on an ambiguous or casual request.
 
     Simulated: Twitter API v2 has no bulk-delete endpoint, so bookmarks are
-    fetched and deleted one by one.
+    fetched page-by-page and deleted one by one.
     """
     if not check_rate_limit("tweet_actions"):
         raise Exception("Tweet action rate limit exceeded")
-    # Twitter API v2 doesn't have a direct endpoint; simulate by fetching and removing.
-    # Both fetch and delete require OAuth 2.0 User Context.
-    data = _bookmarks_api("GET", params={"max_results": 100})
-    for tweet in data.get("data", []):
-        _bookmarks_api("DELETE", tweet_id=tweet["id"])
-    return {"status": "all bookmarks deleted"}
+    # Twitter API v2 doesn't have a bulk-delete endpoint; fetch all pages and
+    # remove bookmarks one by one. Both fetch and delete require OAuth 2.0.
+    headers, user_id = _get_oauth2_headers_and_user_id()
+    deleted = 0
+    next_token = None
+    while True:
+        params: dict = {"max_results": 100}
+        if next_token:
+            params["pagination_token"] = next_token
+        data = _bookmarks_request("GET", headers, user_id, params=params)
+        tweets = data.get("data", [])
+        if not tweets:
+            break
+        for tweet in tweets:
+            if not check_rate_limit("tweet_actions"):
+                raise Exception(
+                    f"Tweet action rate limit exceeded after deleting {deleted} bookmarks"
+                )
+            _bookmarks_request("DELETE", headers, user_id, tweet_id=tweet["id"])
+            deleted += 1
+        next_token = data.get("meta", {}).get("next_token")
+        if not next_token:
+            break
+    return {"status": "all bookmarks deleted", "deleted_count": deleted}
 
 @server.tool(name="get_bookmarks", description="Retrieves the authenticated user's bookmarked tweets. Requires Basic access tier or higher.")
 async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None) -> List[Dict]:
     """Fetches the authenticated user's bookmarked tweets.
 
     Requires TWITTER_OAUTH2_USER_ACCESS_TOKEN — a user-scoped OAuth 2.0 token
-    obtained via the PKCE authorization flow with bookmark.read and users.read scopes.
+    obtained via the PKCE authorization flow with bookmark.read and users.read
+    scopes.
 
     Args:
-        count (Optional[int]): Number of bookmarks to retrieve. Default 100. Min 1, Max 100.
-        cursor (Optional[str]): Pagination token for fetching the next set of results.
+        count (Optional[int]): Number of bookmarks to retrieve per page.
+            Default 100. Min 1, Max 100.
+        cursor (Optional[str]): Pagination token for fetching the next page of
+            results (pass the next_token from a previous response's meta).
     """
     if not check_rate_limit("tweet_actions"):
         raise Exception("Tweet action rate limit exceeded")
@@ -408,13 +442,14 @@ async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None
         effective_count = 100
     else:
         effective_count = count
+    headers, user_id = _get_oauth2_headers_and_user_id()
     params: dict = {
         "max_results": effective_count,
         "tweet.fields": "id,text,created_at,author_id",
     }
     if cursor:
         params["pagination_token"] = cursor
-    data = _bookmarks_api("GET", params=params)
+    data = _bookmarks_request("GET", headers, user_id, params=params)
     return data.get("data", [])
 
 # Timeline & Search Tools

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -63,6 +63,28 @@ def initialize_twitter_clients() -> tuple[tweepy.Client, tweepy.API]:
 
     return _twitter_client, _twitter_v1_api
 
+
+def _make_oauth2_bookmarks_client() -> tweepy.Client:
+    """Return a Tweepy client using the OAuth 2.0 user access token.
+
+    The bookmarks endpoint (/2/users/:id/bookmarks) requires OAuth 2.0 User
+    Context. It rejects both app-only bearer tokens and OAuth 1.0a. A user
+    OAuth 2.0 token — obtained via the PKCE authorization flow — is passed as
+    the bearer token, which satisfies the requirement.
+
+    Set TWITTER_OAUTH2_USER_ACCESS_TOKEN to the token produced by the PKCE
+    flow (tweepy.OAuth2UserHandler).
+    """
+    token = os.getenv("TWITTER_OAUTH2_USER_ACCESS_TOKEN")
+    if not token:
+        raise EnvironmentError(
+            "Missing required environment variable: TWITTER_OAUTH2_USER_ACCESS_TOKEN. "
+            "Obtain one via the PKCE flow (tweepy.OAuth2UserHandler) with "
+            "bookmark.read and users.read scopes."
+        )
+    return tweepy.Client(bearer_token=token)
+
+
 # Rate limiting configuration
 RATE_LIMITS = {
     "tweet_actions": {"limit": 300, "window": timedelta(minutes=15)},
@@ -88,28 +110,6 @@ def check_rate_limit(action_type: str) -> bool:
         return False
     counter["count"] += 1
     return True
-
-
-def _get_bookmarks_with_user_auth(client: tweepy.Client, max_results: int = 100, pagination_token: Optional[str] = None):
-    """Fetch bookmarks using OAuth 1.0a user context.
-
-    tweepy.Client.get_bookmarks() does not expose a user_auth parameter and
-    always defaults to bearer token auth, which the bookmarks endpoint rejects
-    with 403. This helper calls _make_request() directly with user_auth=True.
-    """
-    user_id = client._get_authenticating_user_id(oauth_1=True)
-    params = {"max_results": max_results, "tweet.fields": "id,text,created_at,author_id"}
-    if pagination_token:
-        params["pagination_token"] = pagination_token
-    return client._make_request(
-        "GET", f"/2/users/{user_id}/bookmarks",
-        params=params,
-        endpoint_parameters=("expansions", "max_results", "media.fields",
-                             "pagination_token", "place.fields", "poll.fields",
-                             "tweet.fields", "user.fields"),
-        data_type=tweepy.Tweet,
-        user_auth=True
-    )
 
 
 # User Management Tools
@@ -358,7 +358,14 @@ async def delete_all_bookmarks() -> Dict:
         raise Exception("Tweet action rate limit exceeded")
     client, _ = initialize_twitter_clients()
     # Twitter API v2 doesn't have a direct endpoint; simulate by fetching and removing
-    bookmarks = _get_bookmarks_with_user_auth(client)
+    oauth2_client = _make_oauth2_bookmarks_client()
+    user_id = oauth2_client._get_authenticating_user_id()
+    bookmarks = oauth2_client._make_request(
+        "GET", f"/2/users/{user_id}/bookmarks",
+        params={"max_results": 100},
+        endpoint_parameters=("max_results",),
+        data_type=tweepy.Tweet,
+    )
     for bookmark in (bookmarks.data or []):
         client.remove_bookmark(tweet_id=bookmark.id)
     return {"status": "all bookmarks deleted"}
@@ -367,14 +374,15 @@ async def delete_all_bookmarks() -> Dict:
 async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None) -> List[Dict]:
     """Fetches the authenticated user's bookmarked tweets.
 
+    Requires TWITTER_OAUTH2_USER_ACCESS_TOKEN — a user-scoped OAuth 2.0 token
+    obtained via the PKCE flow with bookmark.read and users.read scopes.
+
     Args:
         count (Optional[int]): Number of bookmarks to retrieve. Default 100. Min 1, Max 100.
         cursor (Optional[str]): Pagination token for fetching the next set of results.
-            Maps to Tweepy's pagination_token parameter.
     """
     if not check_rate_limit("tweet_actions"):
         raise Exception("Tweet action rate limit exceeded")
-    client, _ = initialize_twitter_clients()
     if count is None:
         effective_count = 100
     elif count < 1:
@@ -383,7 +391,20 @@ async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None
         effective_count = 100
     else:
         effective_count = count
-    bookmarks = _get_bookmarks_with_user_auth(client, max_results=effective_count, pagination_token=cursor)
+    oauth2_client = _make_oauth2_bookmarks_client()
+    user_id = oauth2_client._get_authenticating_user_id()
+    bookmarks = oauth2_client._make_request(
+        "GET", f"/2/users/{user_id}/bookmarks",
+        params={
+            "max_results": effective_count,
+            "pagination_token": cursor,
+            "tweet.fields": "id,text,created_at,author_id",
+        },
+        endpoint_parameters=("expansions", "max_results", "media.fields",
+                             "pagination_token", "place.fields", "poll.fields",
+                             "tweet.fields", "user.fields"),
+        data_type=tweepy.Tweet,
+    )
     return [tweet.data for tweet in (bookmarks.data or [])]
 
 # Timeline & Search Tools

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -337,21 +337,32 @@ async def delete_all_bookmarks() -> Dict:
     client, _ = initialize_twitter_clients()
     # Twitter API v2 doesn't have a direct endpoint; simulate by fetching and removing
     bookmarks = client.get_bookmarks()
-    for bookmark in bookmarks.data:
-        client.remove_bookmark(tweet_id=bookmark["id"])
+    for bookmark in (bookmarks.data or []):
+        client.remove_bookmark(tweet_id=bookmark.id)
     return {"status": "all bookmarks deleted"}
 
-@server.tool(name="get_bookmarks", description="Retrieves the authenticated user's bookmarked tweets")
+@server.tool(name="get_bookmarks", description="Retrieves the authenticated user's bookmarked tweets. Requires Basic access tier or higher.")
 async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None) -> List[Dict]:
     """Fetches the authenticated user's bookmarked tweets.
 
     Args:
-        count (Optional[int]): Number of bookmarks to retrieve. Default 100. Max 100.
+        count (Optional[int]): Number of bookmarks to retrieve. Default 100. Min 1, Max 100.
         cursor (Optional[str]): Pagination token for fetching the next set of results.
+            Maps to Tweepy's pagination_token parameter.
     """
+    if not check_rate_limit("tweet_actions"):
+        raise Exception("Tweet action rate limit exceeded")
     client, _ = initialize_twitter_clients()
+    if count is None:
+        effective_count = 100
+    elif count < 1:
+        effective_count = 1
+    elif count > 100:
+        effective_count = 100
+    else:
+        effective_count = count
     bookmarks = client.get_bookmarks(
-        max_results=count,
+        max_results=effective_count,
         pagination_token=cursor,
         tweet_fields=["id", "text", "created_at", "author_id"]
     )

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -336,7 +336,7 @@ async def delete_all_bookmarks() -> Dict:
         raise Exception("Tweet action rate limit exceeded")
     client, _ = initialize_twitter_clients()
     # Twitter API v2 doesn't have a direct endpoint; simulate by fetching and removing
-    bookmarks = client.get_bookmarks()
+    bookmarks = client.get_bookmarks(user_auth=True)
     for bookmark in (bookmarks.data or []):
         client.remove_bookmark(tweet_id=bookmark.id)
     return {"status": "all bookmarks deleted"}
@@ -364,7 +364,8 @@ async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None
     bookmarks = client.get_bookmarks(
         max_results=effective_count,
         pagination_token=cursor,
-        tweet_fields=["id", "text", "created_at", "author_id"]
+        tweet_fields=["id", "text", "created_at", "author_id"],
+        user_auth=True
     )
     return [tweet.data for tweet in (bookmarks.data or [])]
 

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -367,9 +367,17 @@ async def delete_bookmark(tweet_id: str) -> Dict:
     result = client.remove_bookmark(tweet_id=tweet_id)
     return {"tweet_id": tweet_id, "bookmarked": not result.data["bookmarked"]}
 
-@server.tool(name="delete_all_bookmarks", description="Deletes all bookmarks (simulated)")
+@server.tool(name="delete_all_bookmarks", description="DESTRUCTIVE AND IRREVERSIBLE: Permanently deletes ALL bookmarks one by one. This cannot be undone. Always confirm explicitly with the user before calling this tool.")
 async def delete_all_bookmarks() -> Dict:
-    """Deletes all bookmarks. (Simulated as Twitter API v2 doesn't have a direct endpoint for this. Fetches all bookmarks and deletes them one by one.)"""
+    """Permanently deletes all of the authenticated user's bookmarks. IRREVERSIBLE.
+
+    WARNING: This action cannot be undone. Every bookmark will be permanently
+    removed. You MUST obtain explicit confirmation from the user before calling
+    this tool. Do not call this based on an ambiguous or casual request.
+
+    Simulated: Twitter API v2 has no bulk-delete endpoint, so bookmarks are
+    fetched and deleted one by one.
+    """
     if not check_rate_limit("tweet_actions"):
         raise Exception("Tweet action rate limit exceeded")
     # Twitter API v2 doesn't have a direct endpoint; simulate by fetching and removing.

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -341,6 +341,22 @@ async def delete_all_bookmarks() -> Dict:
         client.remove_bookmark(tweet_id=bookmark["id"])
     return {"status": "all bookmarks deleted"}
 
+@server.tool(name="get_bookmarks", description="Retrieves the authenticated user's bookmarked tweets")
+async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None) -> List[Dict]:
+    """Fetches the authenticated user's bookmarked tweets.
+
+    Args:
+        count (Optional[int]): Number of bookmarks to retrieve. Default 100. Max 100.
+        cursor (Optional[str]): Pagination token for fetching the next set of results.
+    """
+    client, _ = initialize_twitter_clients()
+    bookmarks = client.get_bookmarks(
+        max_results=count,
+        pagination_token=cursor,
+        tweet_fields=["id", "text", "created_at", "author_id"]
+    )
+    return [tweet.data for tweet in (bookmarks.data or [])]
+
 # Timeline & Search Tools
 @server.tool(name="get_timeline", description="Get tweets from your home timeline (For You)")
 async def get_timeline(count: Optional[int] = 100, seen_tweet_ids: Optional[List[str]] = None, cursor: Optional[str] = None) -> List[Dict]:


### PR DESCRIPTION
## Summary

Adds a `get_bookmarks` tool and fixes `delete_all_bookmarks` to work correctly with the X API v2 bookmarks endpoint, which requires **OAuth 2.0 User Context** (PKCE). Neither app-only bearer tokens nor OAuth 1.0a are accepted.

## Approach

The bookmarks endpoint is the only endpoint in this server that requires OAuth 2.0 User Context. Rather than rearchitecting the entire Tweepy client setup, bookmark operations use a lightweight `_bookmarks_request()` helper that calls the X API v2 directly via `requests` (already a Tweepy dependency) with the user-scoped token as a Bearer.

A new env var `TWITTER_OAUTH2_USER_ACCESS_TOKEN` is required for bookmark tools only. All other tools continue to work with the existing OAuth 1.0a / bearer token setup.

## Changes

### `src/x_twitter_mcp/server.py`
- Add `_get_oauth2_headers_and_user_id()` — resolves the user ID once per operation via `/2/users/me` and returns reusable headers
- Add `_bookmarks_request()` — makes a single bookmark API request with 30s timeout
- `get_bookmarks` — new tool, returns up to 100 bookmarks per page with cursor-based pagination
- `delete_all_bookmarks` — now paginates through all bookmark pages (not just first 100), checks rate limit per-delete, uses OAuth 2.0 for both fetch and delete, and includes destructive-action warnings in the tool description

### `.env.example`
- Add `TWITTER_OAUTH2_USER_ACCESS_TOKEN` with setup instructions

### `smithery.yaml`
- Add optional `twitterOauth2UserAccessToken` config property (not in `required` — only needed for bookmark tools)

### `README.md`
- Add "Obtaining an OAuth 2.0 User Token" section with PKCE setup guide
- Add `get_bookmarks` tool documentation
- Update `delete_all_bookmarks` documentation (destructive warning, OAuth 2.0 requirement)
- Add `TWITTER_OAUTH2_USER_ACCESS_TOKEN` to Claude Desktop config examples
- Add bookmark 403 troubleshooting entry

## Review feedback addressed

- Paginate through all bookmarks in `delete_all_bookmarks` (not just first 100)
- Per-delete rate limit check in the delete loop
- Cache user_id per operation (split `_bookmarks_api` into two functions)
- Add 30s timeout to all HTTP requests
- Fix README "800 most recent" claim to match actual per-page behavior
- Align PR title/description with OAuth 2.0 implementation (not OAuth 1.0a)