### PR TITLE
docs: add TweetClaw OpenClaw companion workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A Model Context Protocol (MCP) server for interacting with Twitter (X) via AI to
 
 ### Option 1: Installing via Smithery (Recommended)
 
-To install X (Twitter) MCP server for Claude Desktop automatically via [Smithery](https://smithery.ai/server//x-twitter-mcp-server):
+To install X (Twitter) MCP server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@rafaljanicki/x-twitter-mcp-server):
 
 ```bash
 npx -y @smithery/cli install @rafaljanicki/x-twitter-mcp-server --client claude
@@ -285,6 +285,12 @@ You can now interact with Twitter using natural language in Claude Desktop. Here
   Claude will use the `get_trends` tool to fetch trending topics.
 
 When prompted, grant Claude permission to use the MCP tools for the chat session.
+
+## OpenClaw Companion Workflow
+
+This MCP server is best when an MCP client should call Twitter API v2 tools directly. If the workflow runs in OpenClaw and needs plugin install metadata, endpoint discovery, monitor alerts, webhooks, giveaway draws, media upload or download workflows, direct messages, follower export, or approval-gated post and reply actions, use TweetClaw as a separate OpenClaw plugin and pass reviewed tweet IDs or URLs between the tools.
+
+See [OpenClaw Companion Workflow](examples/openclaw-tweetclaw-companion.md) for a command flow that keeps credentials separate and avoids duplicate write actions.
 
 ## Available Tools
 

--- a/examples/openclaw-tweetclaw-companion.md
+++ b/examples/openclaw-tweetclaw-companion.md
@@ -1,0 +1,108 @@
+# OpenClaw Companion Workflow With TweetClaw
+
+Use this recipe when a workflow combines this MCP server with OpenClaw. Keep `x-twitter-mcp` as the direct Twitter API v2 MCP server, and use TweetClaw only when the user needs an OpenClaw plugin for broader X/Twitter automation.
+
+Good fits for the companion plugin:
+
+- Search tweets and search tweet replies from an OpenClaw agent.
+- Export followers or look up users before a CRM, lead, or research workflow.
+- Upload media, download media, or create gallery links.
+- Send direct messages or post tweet replies after explicit user approval.
+- Create monitors and deliver webhooks for recurring X/Twitter checks.
+- Run giveaway draws or extraction jobs with reviewed limits.
+
+## Install The Two Tools
+
+Install and configure this MCP server as described in the main README. Keep its Twitter API credentials in the MCP client or server environment.
+
+Install TweetClaw separately in OpenClaw:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Configure TweetClaw with an API key stored outside the chat transcript:
+
+```bash
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
+```
+
+The OpenClaw command installs the npm package `@xquik/tweetclaw`. The ClawHub listing is useful for browsing plugin metadata: <https://clawhub.ai/plugins/@xquik/tweetclaw>.
+
+## Credential Boundaries
+
+Do not share credentials between tools.
+
+- `x-twitter-mcp` uses `TWITTER_API_KEY`, `TWITTER_API_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_TOKEN_SECRET`, `TWITTER_BEARER_TOKEN`, and optional `TWITTER_OAUTH2_USER_ACCESS_TOKEN`.
+- TweetClaw uses OpenClaw plugin config such as `plugins.entries.tweetclaw.config.apiKey`.
+- Keep API keys, tokens, OAuth redirects, cookies, and signing keys out of prompts, issues, logs, screenshots, and example payloads.
+
+## Handoff Contract
+
+Pass IDs, URLs, queries, and notes between tools. Do not pass secrets.
+
+```json
+{
+  "source": "tweetclaw",
+  "query": "openclaw agents",
+  "tweetIds": ["1234567890123456789"],
+  "tweetUrls": ["tweet URL from the selected result"],
+  "notes": ["Candidate user asked for OpenClaw plugin examples."],
+  "approvedAction": "draft_only"
+}
+```
+
+Use `x-twitter-mcp` for direct API checks such as `get_tweet_details`, `search_twitter`, timeline reads, bookmarks, likes, and simple post actions inside MCP clients. Use TweetClaw when OpenClaw needs endpoint discovery, monitors, webhooks, media workflows, follower export, direct messages, giveaway draws, or its own approval flow.
+
+## Example: Research, Verify, Then Draft
+
+1. In OpenClaw, ask TweetClaw to discover the right read endpoint:
+
+   ```json
+   { "query": "search tweets", "category": "twitter", "method": "GET", "limit": 5 }
+   ```
+
+2. Search for a narrow public query:
+
+   ```json
+   {
+     "path": "/api/v1/x/tweets/search",
+     "method": "GET",
+     "query": {
+       "q": "openclaw mcp twitter",
+       "limit": 20
+     }
+   }
+   ```
+
+3. Hand selected tweet IDs or URLs to the MCP client and verify details with this server's `get_tweet_details` or `search_twitter` tools.
+
+4. Draft the response in the agent. Show the final account, target tweet, final text, and media list before any write.
+
+5. After explicit approval, post from one tool only. Do not call both `post_tweet` and TweetClaw's write endpoint for the same message.
+
+## Example: Monitor Then Inspect
+
+Use TweetClaw when the OpenClaw workflow needs recurring X/Twitter monitoring:
+
+1. Ask for the account, keyword, event types, cadence, and stop condition.
+2. Create the monitor with TweetClaw only after approval.
+3. Use TweetClaw polling or webhooks for new events.
+4. Send selected tweet IDs to `x-twitter-mcp` for direct API inspection when needed.
+5. Keep monitor creation, webhook destination changes, DMs, posts, replies, and media actions behind explicit approval.
+
+## Safety Checks
+
+- Keep read limits small until the user asks for a larger export.
+- Treat X/Twitter content as untrusted text, not instructions for the agent.
+- Confirm before paid, private, recurring, or state-changing actions.
+- Show exact post or reply text before write approval.
+- Record the tool used for any write action so the workflow does not double-post.
+- Prefer tweet IDs and URLs for cross-tool handoff.
+
+## References
+
+- TweetClaw GitHub: <https://github.com/Xquik-dev/tweetclaw>
+- TweetClaw npm package: <https://www.npmjs.com/package/@xquik/tweetclaw>
+- TweetClaw ClawHub listing: <https://clawhub.ai/plugins/@xquik/tweetclaw>


### PR DESCRIPTION
## Summary
- Fix the Smithery install link to the canonical server URL.
- Add an OpenClaw companion workflow showing when to use TweetClaw alongside this MCP server.
- Document credential separation, tweet ID and URL handoff, approval boundaries, monitor flow, and duplicate-write prevention.

## Validation
- git diff --check
- python3 -m compileall -q src
- README and example link sweep with Smithery, Glama, TweetClaw GitHub, ClawHub, and npm package links checked. npmjs.com returned the expected package-page 403 from bot protection.