### PR TITLE
Add optional Hermes Tweet-compatible search backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If you prefer to install from the source repository:
     - Optional: to route only `search_twitter` through an Xquik read backend while keeping all other tools on Twitter API credentials:
       ```
       SEARCH_BACKEND=xquik
+      HERMES_TWEET_API_KEY=your_hermes_tweet_api_key
       XQUIK_API_KEY=your_xquik_api_key
       XQUIK_BASE_URL=https://xquik.com
       XQUIK_AUTH_SCHEME=api-key
@@ -148,7 +149,7 @@ Run the server as an HTTP service with Streamable HTTP and SSE endpoints.
    ```
    To use the optional Xquik search backend for `search_twitter`, include:
    ```json
-   {"searchBackend":"xquik","xquikApiKey":"...","xquikBaseUrl":"https://xquik.com","xquikAuthScheme":"api-key"}
+   {"searchBackend":"xquik","hermesTweetApiKey":"...","xquikBaseUrl":"https://xquik.com","xquikAuthScheme":"api-key"}
    ```
    Encode and call `initialize`:
    ```bash
@@ -480,7 +481,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   Search Twitter for recent tweets about AI, limit to 10.
   ```
   Claude will return up to 10 recent tweets about AI.
-- **Optional Xquik backend**: Set `SEARCH_BACKEND=xquik` to route this read-only search tool through Xquik. The rest of the MCP tools continue using Twitter API credentials.
+- **Optional Xquik backend**: Set `SEARCH_BACKEND=xquik` and `HERMES_TWEET_API_KEY` to route this read-only search tool through a Hermes Tweet-compatible Xquik read endpoint. The rest of the MCP tools continue using Twitter API credentials. `XQUIK_API_KEY` remains supported as a compatibility alias.
 
 #### `get_trends`
 - **Description**: Retrieves trending topics on Twitter.
@@ -529,7 +530,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
 
 - **Xquik search returns authentication errors**:
     - Set `SEARCH_BACKEND=xquik`.
-    - Provide `XQUIK_API_KEY`.
+    - Provide `HERMES_TWEET_API_KEY` or `XQUIK_API_KEY`.
     - Use `XQUIK_AUTH_SCHEME=api-key` unless your endpoint expects bearer auth.
 
 - **Syntax Warnings**:

--- a/README.md
+++ b/README.md
@@ -84,14 +84,13 @@ If you prefer to install from the source repository:
       TWITTER_OAUTH2_USER_ACCESS_TOKEN=your_oauth2_user_token
       ```
       See [Obtaining an OAuth 2.0 User Token](#obtaining-an-oauth-20-user-token) below.
-    - Optional: to route only `search_twitter` through a Hermes Tweet/Xquik read backend while keeping all other tools on Twitter API credentials:
+    - Optional: to route only `search_twitter` through an Xquik read backend while keeping all other tools on Twitter API credentials:
       ```
       SEARCH_BACKEND=xquik
       XQUIK_API_KEY=your_xquik_api_key
       XQUIK_BASE_URL=https://xquik.com
       XQUIK_AUTH_SCHEME=api-key
       ```
-      `SEARCH_BACKEND=hermes-tweet` and `HERMES_TWEET_API_KEY` are accepted aliases.
 
 ## Obtaining an OAuth 2.0 User Token
 
@@ -147,7 +146,7 @@ Run the server as an HTTP service with Streamable HTTP and SSE endpoints.
    ```json
    {"twitterApiKey":"...","twitterApiSecret":"...","twitterAccessToken":"...","twitterAccessTokenSecret":"...","twitterBearerToken":"..."}
    ```
-   To use the optional Hermes Tweet/Xquik search backend for `search_twitter`, include:
+   To use the optional Xquik search backend for `search_twitter`, include:
    ```json
    {"searchBackend":"xquik","xquikApiKey":"...","xquikBaseUrl":"https://xquik.com","xquikAuthScheme":"api-key"}
    ```
@@ -481,7 +480,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   Search Twitter for recent tweets about AI, limit to 10.
   ```
   Claude will return up to 10 recent tweets about AI.
-- **Optional Hermes Tweet/Xquik backend**: Set `SEARCH_BACKEND=xquik` or `SEARCH_BACKEND=hermes-tweet` to route this read-only search tool through Hermes Tweet/Xquik. The rest of the MCP tools continue using Twitter API credentials.
+- **Optional Xquik backend**: Set `SEARCH_BACKEND=xquik` to route this read-only search tool through Xquik. The rest of the MCP tools continue using Twitter API credentials.
 
 #### `get_trends`
 - **Description**: Retrieves trending topics on Twitter.
@@ -528,9 +527,9 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
     - `get_bookmarks` and `delete_all_bookmarks` require `TWITTER_OAUTH2_USER_ACCESS_TOKEN`. App-only bearer tokens and OAuth 1.0a are rejected by the bookmarks endpoint.
     - See [Obtaining an OAuth 2.0 User Token](#obtaining-an-oauth-20-user-token) for setup instructions.
 
-- **Hermes Tweet/Xquik search returns authentication errors**:
-    - Set `SEARCH_BACKEND=xquik` or `SEARCH_BACKEND=hermes-tweet`.
-    - Provide `XQUIK_API_KEY` or `HERMES_TWEET_API_KEY`.
+- **Xquik search returns authentication errors**:
+    - Set `SEARCH_BACKEND=xquik`.
+    - Provide `XQUIK_API_KEY`.
     - Use `XQUIK_AUTH_SCHEME=api-key` unless your endpoint expects bearer auth.
 
 - **Syntax Warnings**:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ If you prefer to install from the source repository:
       TWITTER_OAUTH2_USER_ACCESS_TOKEN=your_oauth2_user_token
       ```
       See [Obtaining an OAuth 2.0 User Token](#obtaining-an-oauth-20-user-token) below.
+    - Optional: to route only `search_twitter` through a Hermes Tweet/Xquik read backend while keeping all other tools on Twitter API credentials:
+      ```
+      SEARCH_BACKEND=xquik
+      XQUIK_API_KEY=your_xquik_api_key
+      XQUIK_BASE_URL=https://xquik.com
+      XQUIK_AUTH_SCHEME=api-key
+      ```
+      `SEARCH_BACKEND=hermes-tweet` and `HERMES_TWEET_API_KEY` are accepted aliases.
 
 ## Obtaining an OAuth 2.0 User Token
 
@@ -138,6 +146,10 @@ Run the server as an HTTP service with Streamable HTTP and SSE endpoints.
 4. Pass config per-request (recommended in Smithery) via base64-encoded `config` query parameter. Example config JSON:
    ```json
    {"twitterApiKey":"...","twitterApiSecret":"...","twitterAccessToken":"...","twitterAccessTokenSecret":"...","twitterBearerToken":"..."}
+   ```
+   To use the optional Hermes Tweet/Xquik search backend for `search_twitter`, include:
+   ```json
+   {"searchBackend":"xquik","xquikApiKey":"...","xquikBaseUrl":"https://xquik.com","xquikAuthScheme":"api-key"}
    ```
    Encode and call `initialize`:
    ```bash
@@ -469,6 +481,7 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
   Search Twitter for recent tweets about AI, limit to 10.
   ```
   Claude will return up to 10 recent tweets about AI.
+- **Optional Hermes Tweet/Xquik backend**: Set `SEARCH_BACKEND=xquik` or `SEARCH_BACKEND=hermes-tweet` to route this read-only search tool through Hermes Tweet/Xquik. The rest of the MCP tools continue using Twitter API credentials.
 
 #### `get_trends`
 - **Description**: Retrieves trending topics on Twitter.
@@ -514,6 +527,11 @@ Below is a list of all tools provided by the `x-twitter-mcp` server, along with 
 - **Bookmark tools return 403**:
     - `get_bookmarks` and `delete_all_bookmarks` require `TWITTER_OAUTH2_USER_ACCESS_TOKEN`. App-only bearer tokens and OAuth 1.0a are rejected by the bookmarks endpoint.
     - See [Obtaining an OAuth 2.0 User Token](#obtaining-an-oauth-20-user-token) for setup instructions.
+
+- **Hermes Tweet/Xquik search returns authentication errors**:
+    - Set `SEARCH_BACKEND=xquik` or `SEARCH_BACKEND=hermes-tweet`.
+    - Provide `XQUIK_API_KEY` or `HERMES_TWEET_API_KEY`.
+    - Use `XQUIK_AUTH_SCHEME=api-key` unless your endpoint expects bearer auth.
 
 - **Syntax Warnings**:
     - If you see `SyntaxWarning` messages from Tweepy, they are due to docstring issues in Tweepy with Python 3.13. The server includes a warning suppression to handle this.

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,4 +1,4 @@
-# Smithery configuration file: https://smithery.ai/docs/build/project-config/smithery-yaml
+# Smithery configuration file: https://smithery.ai/docs/build
 runtime: "container"
 build:
   dockerfile: "Dockerfile"
@@ -33,19 +33,13 @@ startCommand:
         description: "OAuth 2.0 user access token (PKCE flow). Required for bookmark operations (get_bookmarks, delete_all_bookmarks). Obtain via tweepy.OAuth2UserHandler with bookmark.read, bookmark.write, and users.read scopes."
       searchBackend:
         type: string
-        description: "Optional read backend for search_twitter. Use xquik or hermes-tweet to route search through Hermes Tweet/Xquik while leaving other tools on Twitter API credentials."
+        description: "Optional read backend for search_twitter. Use xquik to route search through Xquik while leaving other tools on Twitter API credentials."
       xquikApiKey:
         type: string
-        description: Optional Xquik API key for the Hermes Tweet/Xquik search backend.
-      hermesTweetApiKey:
-        type: string
-        description: Optional Hermes Tweet API key alias for the Xquik search backend.
+        description: Optional Xquik API key for the Xquik search backend.
       xquikBaseUrl:
         type: string
         description: Optional Xquik-compatible base URL. Defaults to https://xquik.com.
-      hermesTweetBaseUrl:
-        type: string
-        description: Optional Hermes Tweet-compatible base URL alias.
       xquikAuthScheme:
         type: string
         description: Optional auth scheme for the Xquik search backend. Use api-key or bearer.

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -31,9 +31,29 @@ startCommand:
       twitterOauth2UserAccessToken:
         type: string
         description: "OAuth 2.0 user access token (PKCE flow). Required for bookmark operations (get_bookmarks, delete_all_bookmarks). Obtain via tweepy.OAuth2UserHandler with bookmark.read, bookmark.write, and users.read scopes."
+      searchBackend:
+        type: string
+        description: "Optional read backend for search_twitter. Use xquik or hermes-tweet to route search through Hermes Tweet/Xquik while leaving other tools on Twitter API credentials."
+      xquikApiKey:
+        type: string
+        description: Optional Xquik API key for the Hermes Tweet/Xquik search backend.
+      hermesTweetApiKey:
+        type: string
+        description: Optional Hermes Tweet API key alias for the Xquik search backend.
+      xquikBaseUrl:
+        type: string
+        description: Optional Xquik-compatible base URL. Defaults to https://xquik.com.
+      hermesTweetBaseUrl:
+        type: string
+        description: Optional Hermes Tweet-compatible base URL alias.
+      xquikAuthScheme:
+        type: string
+        description: Optional auth scheme for the Xquik search backend. Use api-key or bearer.
   exampleConfig:
     twitterApiKey: ABC123KEY
     twitterApiSecret: DEF456SECRET
     twitterAccessToken: GHI789TOKEN
     twitterAccessTokenSecret: JKL012SECRET
     twitterBearerToken: MNO345BEARER
+    searchBackend: xquik
+    xquikApiKey: XQ_SAMPLE_KEY

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -34,9 +34,12 @@ startCommand:
       searchBackend:
         type: string
         description: "Optional read backend for search_twitter. Use xquik to route search through Xquik while leaving other tools on Twitter API credentials."
+      hermesTweetApiKey:
+        type: string
+        description: Optional Hermes Tweet-compatible API key for the Xquik search backend.
       xquikApiKey:
         type: string
-        description: Optional Xquik API key for the Xquik search backend.
+        description: Optional compatibility alias for the Xquik search backend API key.
       xquikBaseUrl:
         type: string
         description: Optional Xquik-compatible base URL. Defaults to https://xquik.com.
@@ -50,4 +53,4 @@ startCommand:
     twitterAccessTokenSecret: JKL012SECRET
     twitterBearerToken: MNO345BEARER
     searchBackend: xquik
-    xquikApiKey: XQ_SAMPLE_KEY
+    hermesTweetApiKey: XQ_SAMPLE_KEY

--- a/src/x_twitter_mcp/middleware.py
+++ b/src/x_twitter_mcp/middleware.py
@@ -1,9 +1,43 @@
 import base64
 import json
+import os
 from typing import Any
 from urllib.parse import parse_qs, unquote
 
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+_ENV_MAP = {
+    "twitterApiKey": "TWITTER_API_KEY",
+    "twitterApiSecret": "TWITTER_API_SECRET",
+    "twitterAccessToken": "TWITTER_ACCESS_TOKEN",
+    "twitterAccessTokenSecret": "TWITTER_ACCESS_TOKEN_SECRET",
+    "twitterBearerToken": "TWITTER_BEARER_TOKEN",
+    "twitterOauth2UserAccessToken": "TWITTER_OAUTH2_USER_ACCESS_TOKEN",
+    "searchBackend": "SEARCH_BACKEND",
+    "xquikApiKey": "XQUIK_API_KEY",
+    "hermesTweetApiKey": "HERMES_TWEET_API_KEY",
+    "xquikBaseUrl": "XQUIK_BASE_URL",
+    "hermesTweetBaseUrl": "HERMES_TWEET_BASE_URL",
+    "xquikAuthScheme": "XQUIK_AUTH_SCHEME",
+}
+
+
+def _apply_config_env(config: dict[str, Any]) -> dict[str, str | None]:
+    previous = {env_key: os.environ.get(env_key) for env_key in _ENV_MAP.values()}
+    for key, env_key in _ENV_MAP.items():
+        value = config.get(key)
+        if value:
+            os.environ[env_key] = str(value)
+    return previous
+
+
+def _restore_env(previous: dict[str, str | None]) -> None:
+    for env_key, value in previous.items():
+        if value is None:
+            os.environ.pop(env_key, None)
+        else:
+            os.environ[env_key] = value
 
 
 class SmitheryConfigMiddleware:
@@ -17,6 +51,7 @@ class SmitheryConfigMiddleware:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        previous_env: dict[str, str | None] | None = None
         if scope.get("type") == "http":
             query = scope.get("query_string", b"").decode()
             config: dict[str, Any] = {}
@@ -33,27 +68,10 @@ class SmitheryConfigMiddleware:
             scope["smithery_config"] = config
 
             # Map config to env vars expected by server.initialize_twitter_clients
-            import os
+            previous_env = _apply_config_env(config)
 
-            env_map = {
-                "twitterApiKey": "TWITTER_API_KEY",
-                "twitterApiSecret": "TWITTER_API_SECRET",
-                "twitterAccessToken": "TWITTER_ACCESS_TOKEN",
-                "twitterAccessTokenSecret": "TWITTER_ACCESS_TOKEN_SECRET",
-                "twitterBearerToken": "TWITTER_BEARER_TOKEN",
-                "twitterOauth2UserAccessToken": "TWITTER_OAUTH2_USER_ACCESS_TOKEN",
-                "searchBackend": "SEARCH_BACKEND",
-                "xquikApiKey": "XQUIK_API_KEY",
-                "hermesTweetApiKey": "HERMES_TWEET_API_KEY",
-                "xquikBaseUrl": "XQUIK_BASE_URL",
-                "hermesTweetBaseUrl": "HERMES_TWEET_BASE_URL",
-                "xquikAuthScheme": "XQUIK_AUTH_SCHEME",
-            }
-
-            for key, env_key in env_map.items():
-                value = config.get(key)
-                if value:
-                    os.environ[env_key] = str(value)
-
-        await self.app(scope, receive, send)
-
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            if previous_env is not None:
+                _restore_env(previous_env)

--- a/src/x_twitter_mcp/middleware.py
+++ b/src/x_twitter_mcp/middleware.py
@@ -41,6 +41,13 @@ class SmitheryConfigMiddleware:
                 "twitterAccessToken": "TWITTER_ACCESS_TOKEN",
                 "twitterAccessTokenSecret": "TWITTER_ACCESS_TOKEN_SECRET",
                 "twitterBearerToken": "TWITTER_BEARER_TOKEN",
+                "twitterOauth2UserAccessToken": "TWITTER_OAUTH2_USER_ACCESS_TOKEN",
+                "searchBackend": "SEARCH_BACKEND",
+                "xquikApiKey": "XQUIK_API_KEY",
+                "hermesTweetApiKey": "HERMES_TWEET_API_KEY",
+                "xquikBaseUrl": "XQUIK_BASE_URL",
+                "hermesTweetBaseUrl": "HERMES_TWEET_BASE_URL",
+                "xquikAuthScheme": "XQUIK_AUTH_SCHEME",
             }
 
             for key, env_key in env_map.items():
@@ -49,5 +56,4 @@ class SmitheryConfigMiddleware:
                     os.environ[env_key] = str(value)
 
         await self.app(scope, receive, send)
-
 

--- a/src/x_twitter_mcp/middleware.py
+++ b/src/x_twitter_mcp/middleware.py
@@ -1,4 +1,5 @@
 import base64
+import contextvars
 import json
 import os
 from typing import Any
@@ -7,6 +8,11 @@ from urllib.parse import parse_qs, unquote
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 
+_SMITHERY_CONFIG: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
+    "smithery_config",
+    default=None,
+)
+
 _ENV_MAP = {
     "twitterApiKey": "TWITTER_API_KEY",
     "twitterApiSecret": "TWITTER_API_SECRET",
@@ -14,12 +20,22 @@ _ENV_MAP = {
     "twitterAccessTokenSecret": "TWITTER_ACCESS_TOKEN_SECRET",
     "twitterBearerToken": "TWITTER_BEARER_TOKEN",
     "twitterOauth2UserAccessToken": "TWITTER_OAUTH2_USER_ACCESS_TOKEN",
-    "searchBackend": "SEARCH_BACKEND",
-    "hermesTweetApiKey": "HERMES_TWEET_API_KEY",
-    "xquikApiKey": "XQUIK_API_KEY",
-    "xquikBaseUrl": "XQUIK_BASE_URL",
-    "xquikAuthScheme": "XQUIK_AUTH_SCHEME",
 }
+
+
+def get_smithery_config_value(*keys: str) -> str | None:
+    config = _SMITHERY_CONFIG.get()
+    if not config:
+        return None
+
+    for key in keys:
+        value = config.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
 
 
 def _apply_config_env(config: dict[str, Any]) -> dict[str, str | None]:
@@ -51,6 +67,7 @@ class SmitheryConfigMiddleware:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         previous_env: dict[str, str | None] | None = None
+        config_token: contextvars.Token | None = None
         if scope.get("type") == "http":
             query = scope.get("query_string", b"").decode()
             config: dict[str, Any] = {}
@@ -60,17 +77,22 @@ class SmitheryConfigMiddleware:
                     parsed = parse_qs(query)
                     enc = parsed.get("config", [""])[0]
                     raw = base64.b64decode(unquote(enc))
-                    config = json.loads(raw)
+                    decoded = json.loads(raw)
+                    if isinstance(decoded, dict):
+                        config = decoded
                 except Exception:
                     config = {}
 
             scope["smithery_config"] = config
 
             # Map config to env vars expected by server.initialize_twitter_clients
+            config_token = _SMITHERY_CONFIG.set(config)
             previous_env = _apply_config_env(config)
 
         try:
             await self.app(scope, receive, send)
         finally:
+            if config_token is not None:
+                _SMITHERY_CONFIG.reset(config_token)
             if previous_env is not None:
                 _restore_env(previous_env)

--- a/src/x_twitter_mcp/middleware.py
+++ b/src/x_twitter_mcp/middleware.py
@@ -16,9 +16,7 @@ _ENV_MAP = {
     "twitterOauth2UserAccessToken": "TWITTER_OAUTH2_USER_ACCESS_TOKEN",
     "searchBackend": "SEARCH_BACKEND",
     "xquikApiKey": "XQUIK_API_KEY",
-    "hermesTweetApiKey": "HERMES_TWEET_API_KEY",
     "xquikBaseUrl": "XQUIK_BASE_URL",
-    "hermesTweetBaseUrl": "HERMES_TWEET_BASE_URL",
     "xquikAuthScheme": "XQUIK_AUTH_SCHEME",
 }
 

--- a/src/x_twitter_mcp/middleware.py
+++ b/src/x_twitter_mcp/middleware.py
@@ -15,6 +15,7 @@ _ENV_MAP = {
     "twitterBearerToken": "TWITTER_BEARER_TOKEN",
     "twitterOauth2UserAccessToken": "TWITTER_OAUTH2_USER_ACCESS_TOKEN",
     "searchBackend": "SEARCH_BACKEND",
+    "hermesTweetApiKey": "HERMES_TWEET_API_KEY",
     "xquikApiKey": "XQUIK_API_KEY",
     "xquikBaseUrl": "XQUIK_BASE_URL",
     "xquikAuthScheme": "XQUIK_AUTH_SCHEME",

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional
 from dotenv import load_dotenv
+from .xquik_search import search_with_xquik, xquik_search_enabled
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -487,6 +488,9 @@ async def search_twitter(query: str, product: Optional[str] = "Top", count: Opti
         count (Optional[int]): Number of tweets to retrieve. Default 100. Min 10, Max 100 for search_recent_tweets.
         cursor (Optional[str]): Pagination token (next_token) for fetching the next set of results.
     """
+    if xquik_search_enabled():
+        return search_with_xquik(query=query, product=product, count=count, cursor=cursor)
+
     sort_order = "relevancy" if product == "Top" else "recency"
     
     # Ensure count is within the allowed range (10-100)

--- a/src/x_twitter_mcp/xquik_search.py
+++ b/src/x_twitter_mcp/xquik_search.py
@@ -22,7 +22,7 @@ def xquik_search_enabled() -> bool:
 
 
 def _api_key() -> Optional[str]:
-    return _non_empty(os.getenv("XQUIK_API_KEY"))
+    return _non_empty(os.getenv("HERMES_TWEET_API_KEY")) or _non_empty(os.getenv("XQUIK_API_KEY"))
 
 
 def _base_url() -> str:

--- a/src/x_twitter_mcp/xquik_search.py
+++ b/src/x_twitter_mcp/xquik_search.py
@@ -6,7 +6,7 @@ import requests
 
 
 _DEFAULT_BASE_URL = "https://xquik.com"
-_XQUIK_BACKENDS = {"xquik", "hermes-tweet", "hermes_tweet"}
+_XQUIK_BACKENDS = {"xquik"}
 
 
 def _non_empty(value: Optional[str]) -> Optional[str]:
@@ -22,15 +22,11 @@ def xquik_search_enabled() -> bool:
 
 
 def _api_key() -> Optional[str]:
-    return _non_empty(os.getenv("XQUIK_API_KEY")) or _non_empty(
-        os.getenv("HERMES_TWEET_API_KEY")
-    )
+    return _non_empty(os.getenv("XQUIK_API_KEY"))
 
 
 def _base_url() -> str:
-    configured = _non_empty(os.getenv("XQUIK_BASE_URL")) or _non_empty(
-        os.getenv("HERMES_TWEET_BASE_URL")
-    )
+    configured = _non_empty(os.getenv("XQUIK_BASE_URL"))
     return configured or _DEFAULT_BASE_URL
 
 

--- a/src/x_twitter_mcp/xquik_search.py
+++ b/src/x_twitter_mcp/xquik_search.py
@@ -4,6 +4,8 @@ from urllib.parse import urljoin
 
 import requests
 
+from .middleware import get_smithery_config_value
+
 
 _DEFAULT_BASE_URL = "https://xquik.com"
 _XQUIK_BACKENDS = {"xquik"}
@@ -17,21 +19,33 @@ def _non_empty(value: Optional[str]) -> Optional[str]:
 
 
 def xquik_search_enabled() -> bool:
-    backend = _non_empty(os.getenv("SEARCH_BACKEND"))
+    backend = get_smithery_config_value("searchBackend") or _non_empty(
+        os.getenv("SEARCH_BACKEND")
+    )
     return backend is not None and backend.lower() in _XQUIK_BACKENDS
 
 
 def _api_key() -> Optional[str]:
-    return _non_empty(os.getenv("HERMES_TWEET_API_KEY")) or _non_empty(os.getenv("XQUIK_API_KEY"))
+    return (
+        get_smithery_config_value("hermesTweetApiKey")
+        or get_smithery_config_value("xquikApiKey")
+        or _non_empty(os.getenv("HERMES_TWEET_API_KEY"))
+        or _non_empty(os.getenv("XQUIK_API_KEY"))
+    )
 
 
 def _base_url() -> str:
-    configured = _non_empty(os.getenv("XQUIK_BASE_URL"))
+    configured = get_smithery_config_value("xquikBaseUrl") or _non_empty(
+        os.getenv("XQUIK_BASE_URL")
+    )
     return configured or _DEFAULT_BASE_URL
 
 
 def _auth_scheme() -> str:
-    return (_non_empty(os.getenv("XQUIK_AUTH_SCHEME")) or "api-key").lower()
+    configured = get_smithery_config_value("xquikAuthScheme") or _non_empty(
+        os.getenv("XQUIK_AUTH_SCHEME")
+    )
+    return (configured or "api-key").lower()
 
 
 def _search_url() -> str:

--- a/src/x_twitter_mcp/xquik_search.py
+++ b/src/x_twitter_mcp/xquik_search.py
@@ -1,0 +1,143 @@
+import os
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+import requests
+
+
+_DEFAULT_BASE_URL = "https://xquik.com"
+_XQUIK_BACKENDS = {"xquik", "hermes-tweet", "hermes_tweet"}
+
+
+def _non_empty(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def xquik_search_enabled() -> bool:
+    backend = _non_empty(os.getenv("SEARCH_BACKEND"))
+    return backend is not None and backend.lower() in _XQUIK_BACKENDS
+
+
+def _api_key() -> Optional[str]:
+    return _non_empty(os.getenv("XQUIK_API_KEY")) or _non_empty(
+        os.getenv("HERMES_TWEET_API_KEY")
+    )
+
+
+def _base_url() -> str:
+    configured = _non_empty(os.getenv("XQUIK_BASE_URL")) or _non_empty(
+        os.getenv("HERMES_TWEET_BASE_URL")
+    )
+    return configured or _DEFAULT_BASE_URL
+
+
+def _auth_scheme() -> str:
+    return (_non_empty(os.getenv("XQUIK_AUTH_SCHEME")) or "api-key").lower()
+
+
+def _search_url() -> str:
+    return urljoin(_base_url().rstrip("/") + "/", "api/v1/x/tweets/search")
+
+
+def _headers() -> Dict[str, str]:
+    api_key = _api_key()
+    if not api_key:
+        return {}
+    if _auth_scheme() == "bearer":
+        return {"Authorization": f"Bearer {api_key}"}
+    return {"X-API-Key": api_key}
+
+
+def _tweet_items(payload: Any) -> List[Dict[str, Any]]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if not isinstance(payload, dict):
+        return []
+
+    for key in ("tweets", "data", "results", "items"):
+        items = payload.get(key)
+        if isinstance(items, list):
+            return [item for item in items if isinstance(item, dict)]
+
+    nested = payload.get("timeline") or payload.get("content")
+    if isinstance(nested, dict):
+        return _tweet_items(nested)
+
+    return []
+
+
+def _first_string(*values: Any) -> Optional[str]:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _author_id(tweet: Dict[str, Any]) -> Optional[str]:
+    author = tweet.get("author") or tweet.get("user")
+    if isinstance(author, dict):
+        return _first_string(
+            author.get("id"),
+            author.get("id_str"),
+            author.get("rest_id"),
+        )
+    return _first_string(tweet.get("author_id"), tweet.get("user_id"), tweet.get("userId"))
+
+
+def normalize_xquik_tweet(tweet: Dict[str, Any]) -> Dict[str, Any]:
+    normalized: Dict[str, Any] = {}
+    tweet_id = _first_string(
+        tweet.get("id"),
+        tweet.get("id_str"),
+        tweet.get("tweet_id"),
+        tweet.get("tweetId"),
+    )
+    text = _first_string(tweet.get("text"), tweet.get("full_text"), tweet.get("content"))
+    created_at = _first_string(tweet.get("created_at"), tweet.get("createdAt"), tweet.get("date"))
+    author_id = _author_id(tweet)
+
+    if tweet_id:
+        normalized["id"] = tweet_id
+    if text:
+        normalized["text"] = text
+    if created_at:
+        normalized["created_at"] = created_at
+    if author_id:
+        normalized["author_id"] = author_id
+
+    return normalized or dict(tweet)
+
+
+def search_with_xquik(
+    query: str,
+    product: Optional[str],
+    count: Optional[int],
+    cursor: Optional[str],
+) -> List[Dict[str, Any]]:
+    if count is None:
+        effective_count = 100
+    elif count < 1:
+        effective_count = 1
+    elif count > 100:
+        effective_count = 100
+    else:
+        effective_count = count
+
+    params: Dict[str, Any] = {
+        "q": query,
+        "limit": effective_count,
+    }
+    if product:
+        params["queryType"] = "Latest" if product == "Latest" else "Top"
+    if cursor:
+        params["cursor"] = cursor
+
+    response = requests.get(_search_url(), headers=_headers(), params=params, timeout=30)
+    response.raise_for_status()
+    return [normalize_xquik_tweet(tweet) for tweet in _tweet_items(response.json())]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -13,6 +13,7 @@ class SmitheryConfigMiddlewareTests(unittest.TestCase):
         self._env = os.environ.copy()
         for key in (
             "SEARCH_BACKEND",
+            "HERMES_TWEET_API_KEY",
             "XQUIK_API_KEY",
             "XQUIK_BASE_URL",
             "XQUIK_AUTH_SCHEME",
@@ -27,13 +28,13 @@ class SmitheryConfigMiddlewareTests(unittest.TestCase):
         async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
             self.assertEqual(scope["smithery_config"]["searchBackend"], "xquik")
             self.assertEqual(os.environ["SEARCH_BACKEND"], "xquik")
-            self.assertEqual(os.environ["XQUIK_API_KEY"], "request-key")
+            self.assertEqual(os.environ["HERMES_TWEET_API_KEY"], "request-key")
 
         config = base64.b64encode(
             json.dumps(
                 {
                     "searchBackend": "xquik",
-                    "xquikApiKey": "request-key",
+                    "hermesTweetApiKey": "request-key",
                 }
             ).encode()
         )
@@ -43,7 +44,7 @@ class SmitheryConfigMiddlewareTests(unittest.TestCase):
         asyncio.run(middleware(scope, None, None))
 
         self.assertIsNone(os.environ.get("SEARCH_BACKEND"))
-        self.assertIsNone(os.environ.get("XQUIK_API_KEY"))
+        self.assertIsNone(os.environ.get("HERMES_TWEET_API_KEY"))
 
     def test_missing_request_config_does_not_keep_stale_search_backend(self) -> None:
         os.environ["SEARCH_BACKEND"] = "xquik"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,69 @@
+import asyncio
+import base64
+import json
+import os
+import unittest
+from typing import Any
+
+from x_twitter_mcp.middleware import SmitheryConfigMiddleware
+
+
+class SmitheryConfigMiddlewareTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._env = os.environ.copy()
+        for key in (
+            "SEARCH_BACKEND",
+            "XQUIK_API_KEY",
+            "HERMES_TWEET_API_KEY",
+            "XQUIK_BASE_URL",
+            "HERMES_TWEET_BASE_URL",
+            "XQUIK_AUTH_SCHEME",
+        ):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env)
+
+    def test_config_env_is_restored_after_http_request(self) -> None:
+        async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+            self.assertEqual(scope["smithery_config"]["searchBackend"], "xquik")
+            self.assertEqual(os.environ["SEARCH_BACKEND"], "xquik")
+            self.assertEqual(os.environ["XQUIK_API_KEY"], "request-key")
+
+        config = base64.b64encode(
+            json.dumps(
+                {
+                    "searchBackend": "xquik",
+                    "xquikApiKey": "request-key",
+                }
+            ).encode()
+        )
+        middleware = SmitheryConfigMiddleware(app)
+        scope = {"type": "http", "query_string": b"config=" + config}
+
+        asyncio.run(middleware(scope, None, None))
+
+        self.assertIsNone(os.environ.get("SEARCH_BACKEND"))
+        self.assertIsNone(os.environ.get("XQUIK_API_KEY"))
+
+    def test_missing_request_config_does_not_keep_stale_search_backend(self) -> None:
+        os.environ["SEARCH_BACKEND"] = "xquik"
+        os.environ["XQUIK_API_KEY"] = "existing-key"
+
+        async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+            self.assertEqual(scope["smithery_config"], {})
+            self.assertEqual(os.environ["SEARCH_BACKEND"], "xquik")
+            self.assertEqual(os.environ["XQUIK_API_KEY"], "existing-key")
+
+        middleware = SmitheryConfigMiddleware(app)
+        scope = {"type": "http", "query_string": b""}
+
+        asyncio.run(middleware(scope, None, None))
+
+        self.assertEqual(os.environ["SEARCH_BACKEND"], "xquik")
+        self.assertEqual(os.environ["XQUIK_API_KEY"], "existing-key")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -14,9 +14,7 @@ class SmitheryConfigMiddlewareTests(unittest.TestCase):
         for key in (
             "SEARCH_BACKEND",
             "XQUIK_API_KEY",
-            "HERMES_TWEET_API_KEY",
             "XQUIK_BASE_URL",
-            "HERMES_TWEET_BASE_URL",
             "XQUIK_AUTH_SCHEME",
         ):
             os.environ.pop(key, None)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -4,8 +4,10 @@ import json
 import os
 import unittest
 from typing import Any
+from unittest.mock import Mock, patch
 
 from x_twitter_mcp.middleware import SmitheryConfigMiddleware
+from x_twitter_mcp.xquik_search import search_with_xquik, xquik_search_enabled
 
 
 class SmitheryConfigMiddlewareTests(unittest.TestCase):
@@ -27,8 +29,9 @@ class SmitheryConfigMiddlewareTests(unittest.TestCase):
     def test_config_env_is_restored_after_http_request(self) -> None:
         async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
             self.assertEqual(scope["smithery_config"]["searchBackend"], "xquik")
-            self.assertEqual(os.environ["SEARCH_BACKEND"], "xquik")
-            self.assertEqual(os.environ["HERMES_TWEET_API_KEY"], "request-key")
+            self.assertTrue(xquik_search_enabled())
+            self.assertIsNone(os.environ.get("SEARCH_BACKEND"))
+            self.assertIsNone(os.environ.get("HERMES_TWEET_API_KEY"))
 
         config = base64.b64encode(
             json.dumps(
@@ -45,6 +48,65 @@ class SmitheryConfigMiddlewareTests(unittest.TestCase):
 
         self.assertIsNone(os.environ.get("SEARCH_BACKEND"))
         self.assertIsNone(os.environ.get("HERMES_TWEET_API_KEY"))
+
+    def test_concurrent_requests_keep_search_backend_config_isolated(self) -> None:
+        async def main() -> None:
+            started = 0
+            both_started = asyncio.Event()
+
+            async def invoke(config: dict[str, str]) -> None:
+                nonlocal started
+
+                async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+                    nonlocal started
+                    started += 1
+                    if started == 2:
+                        both_started.set()
+                    await both_started.wait()
+                    self.assertEqual(scope["smithery_config"]["searchBackend"], "xquik")
+                    self.assertTrue(xquik_search_enabled())
+                    search_with_xquik("AI", "Top", 5, None)
+
+                encoded_config = base64.b64encode(json.dumps(config).encode())
+                middleware = SmitheryConfigMiddleware(app)
+                scope = {"type": "http", "query_string": b"config=" + encoded_config}
+                await middleware(scope, None, None)
+
+            await asyncio.gather(
+                invoke(
+                    {
+                        "searchBackend": "xquik",
+                        "hermesTweetApiKey": "request-key-a",
+                        "xquikBaseUrl": "https://a.example",
+                    }
+                ),
+                invoke(
+                    {
+                        "searchBackend": "xquik",
+                        "hermesTweetApiKey": "request-key-b",
+                        "xquikBaseUrl": "https://b.example",
+                    }
+                ),
+            )
+
+        response = Mock()
+        response.json.return_value = [{"id": "1", "text": "one"}]
+        response.raise_for_status.return_value = None
+
+        with patch("x_twitter_mcp.xquik_search.requests.get", return_value=response) as get:
+            asyncio.run(main())
+
+        calls = [
+            (call.args[0], call.kwargs["headers"])
+            for call in get.call_args_list
+        ]
+        self.assertCountEqual(
+            calls,
+            [
+                ("https://a.example/api/v1/x/tweets/search", {"X-API-Key": "request-key-a"}),
+                ("https://b.example/api/v1/x/tweets/search", {"X-API-Key": "request-key-b"}),
+            ],
+        )
 
     def test_missing_request_config_does_not_keep_stale_search_backend(self) -> None:
         os.environ["SEARCH_BACKEND"] = "xquik"

--- a/tests/test_xquik_search.py
+++ b/tests/test_xquik_search.py
@@ -1,0 +1,101 @@
+import os
+import unittest
+from unittest.mock import Mock, patch
+
+from x_twitter_mcp.xquik_search import (
+    normalize_xquik_tweet,
+    search_with_xquik,
+    xquik_search_enabled,
+)
+
+
+class XquikSearchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._env = os.environ.copy()
+        for key in (
+            "SEARCH_BACKEND",
+            "XQUIK_API_KEY",
+            "HERMES_TWEET_API_KEY",
+            "XQUIK_BASE_URL",
+            "HERMES_TWEET_BASE_URL",
+            "XQUIK_AUTH_SCHEME",
+        ):
+            os.environ.pop(key, None)
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._env)
+
+    def test_backend_aliases_enable_xquik_search(self) -> None:
+        os.environ["SEARCH_BACKEND"] = "hermes-tweet"
+
+        self.assertTrue(xquik_search_enabled())
+
+    def test_blank_xquik_key_falls_back_to_hermes_tweet_key(self) -> None:
+        os.environ["XQUIK_API_KEY"] = " "
+        os.environ["HERMES_TWEET_API_KEY"] = "hermes-key"
+        os.environ["XQUIK_BASE_URL"] = "https://example.test/base"
+        response = Mock()
+        response.json.return_value = {
+            "tweets": [
+                {
+                    "tweet_id": "123",
+                    "full_text": "Hello from Hermes Tweet",
+                    "createdAt": "2026-05-24T00:00:00Z",
+                    "author": {"id_str": "42"},
+                }
+            ]
+        }
+        response.raise_for_status.return_value = None
+
+        with patch("x_twitter_mcp.xquik_search.requests.get", return_value=response) as get:
+            tweets = search_with_xquik("Hermes Tweet", "Latest", 0, "cursor-1")
+
+        self.assertEqual(
+            tweets,
+            [
+                {
+                    "id": "123",
+                    "text": "Hello from Hermes Tweet",
+                    "created_at": "2026-05-24T00:00:00Z",
+                    "author_id": "42",
+                }
+            ],
+        )
+        get.assert_called_once_with(
+            "https://example.test/base/api/v1/x/tweets/search",
+            headers={"X-API-Key": "hermes-key"},
+            params={
+                "q": "Hermes Tweet",
+                "limit": 1,
+                "queryType": "Latest",
+                "cursor": "cursor-1",
+            },
+            timeout=30,
+        )
+
+    def test_bearer_auth_scheme(self) -> None:
+        os.environ["XQUIK_API_KEY"] = "xquik-key"
+        os.environ["XQUIK_AUTH_SCHEME"] = "bearer"
+        response = Mock()
+        response.json.return_value = [{"id": "1", "text": "one"}]
+        response.raise_for_status.return_value = None
+
+        with patch("x_twitter_mcp.xquik_search.requests.get", return_value=response) as get:
+            tweets = search_with_xquik("AI", "Top", 101, None)
+
+        self.assertEqual(tweets, [{"id": "1", "text": "one"}])
+        self.assertEqual(get.call_args.kwargs["headers"], {"Authorization": "Bearer xquik-key"})
+        self.assertEqual(
+            get.call_args.kwargs["params"],
+            {"q": "AI", "limit": 100, "queryType": "Top"},
+        )
+
+    def test_normalize_preserves_unknown_tweet_shapes(self) -> None:
+        tweet = {"unexpected": "value"}
+
+        self.assertEqual(normalize_xquik_tweet(tweet), tweet)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xquik_search.py
+++ b/tests/test_xquik_search.py
@@ -15,9 +15,7 @@ class XquikSearchTests(unittest.TestCase):
         for key in (
             "SEARCH_BACKEND",
             "XQUIK_API_KEY",
-            "HERMES_TWEET_API_KEY",
             "XQUIK_BASE_URL",
-            "HERMES_TWEET_BASE_URL",
             "XQUIK_AUTH_SCHEME",
         ):
             os.environ.pop(key, None)
@@ -26,21 +24,20 @@ class XquikSearchTests(unittest.TestCase):
         os.environ.clear()
         os.environ.update(self._env)
 
-    def test_backend_aliases_enable_xquik_search(self) -> None:
-        os.environ["SEARCH_BACKEND"] = "hermes-tweet"
+    def test_xquik_backend_enables_xquik_search(self) -> None:
+        os.environ["SEARCH_BACKEND"] = "xquik"
 
         self.assertTrue(xquik_search_enabled())
 
-    def test_blank_xquik_key_falls_back_to_hermes_tweet_key(self) -> None:
+    def test_blank_xquik_key_omits_auth_header(self) -> None:
         os.environ["XQUIK_API_KEY"] = " "
-        os.environ["HERMES_TWEET_API_KEY"] = "hermes-key"
         os.environ["XQUIK_BASE_URL"] = "https://example.test/base"
         response = Mock()
         response.json.return_value = {
             "tweets": [
                 {
                     "tweet_id": "123",
-                    "full_text": "Hello from Hermes Tweet",
+                    "full_text": "Hello from Xquik",
                     "createdAt": "2026-05-24T00:00:00Z",
                     "author": {"id_str": "42"},
                 }
@@ -49,14 +46,14 @@ class XquikSearchTests(unittest.TestCase):
         response.raise_for_status.return_value = None
 
         with patch("x_twitter_mcp.xquik_search.requests.get", return_value=response) as get:
-            tweets = search_with_xquik("Hermes Tweet", "Latest", 0, "cursor-1")
+            tweets = search_with_xquik("Xquik", "Latest", 0, "cursor-1")
 
         self.assertEqual(
             tweets,
             [
                 {
                     "id": "123",
-                    "text": "Hello from Hermes Tweet",
+                    "text": "Hello from Xquik",
                     "created_at": "2026-05-24T00:00:00Z",
                     "author_id": "42",
                 }
@@ -64,9 +61,9 @@ class XquikSearchTests(unittest.TestCase):
         )
         get.assert_called_once_with(
             "https://example.test/base/api/v1/x/tweets/search",
-            headers={"X-API-Key": "hermes-key"},
+            headers={},
             params={
-                "q": "Hermes Tweet",
+                "q": "Xquik",
                 "limit": 1,
                 "queryType": "Latest",
                 "cursor": "cursor-1",

--- a/tests/test_xquik_search.py
+++ b/tests/test_xquik_search.py
@@ -14,6 +14,7 @@ class XquikSearchTests(unittest.TestCase):
         self._env = os.environ.copy()
         for key in (
             "SEARCH_BACKEND",
+            "HERMES_TWEET_API_KEY",
             "XQUIK_API_KEY",
             "XQUIK_BASE_URL",
             "XQUIK_AUTH_SCHEME",
@@ -72,6 +73,7 @@ class XquikSearchTests(unittest.TestCase):
         )
 
     def test_bearer_auth_scheme(self) -> None:
+        os.environ["HERMES_TWEET_API_KEY"] = "hermes-key"
         os.environ["XQUIK_API_KEY"] = "xquik-key"
         os.environ["XQUIK_AUTH_SCHEME"] = "bearer"
         response = Mock()
@@ -82,7 +84,7 @@ class XquikSearchTests(unittest.TestCase):
             tweets = search_with_xquik("AI", "Top", 101, None)
 
         self.assertEqual(tweets, [{"id": "1", "text": "one"}])
-        self.assertEqual(get.call_args.kwargs["headers"], {"Authorization": "Bearer xquik-key"})
+        self.assertEqual(get.call_args.kwargs["headers"], {"Authorization": "Bearer hermes-key"})
         self.assertEqual(
             get.call_args.kwargs["params"],
             {"q": "AI", "limit": 100, "queryType": "Top"},


### PR DESCRIPTION
## Summary
- add an optional Hermes Tweet-compatible Xquik backend for the existing `search_twitter` MCP tool
- keep all other Twitter API tools on the current credential path
- wire Smithery per-request config and README setup for `SEARCH_BACKEND=xquik`
- read Xquik search backend settings from request-scoped Smithery config, with env as the static fallback
- prefer `HERMES_TWEET_API_KEY` / `hermesTweetApiKey` while preserving `XQUIK_API_KEY` / `xquikApiKey` compatibility
- remove stale backend aliases from docs, Smithery config, env mapping, and tests
- fix a stale Smithery documentation link

## Validation
- `PYTHONPATH=src uv run --no-project --python 3.12 --with fastmcp --with tweepy --with python-dotenv --with requests --with starlette python -m unittest tests/test_xquik_search.py tests/test_middleware.py`
- `PYTHONPATH=src uv run --no-project --python 3.12 --with fastmcp --with tweepy --with python-dotenv --with requests --with starlette python -m py_compile src/x_twitter_mcp/xquik_search.py src/x_twitter_mcp/server.py src/x_twitter_mcp/middleware.py tests/test_xquik_search.py tests/test_middleware.py`
- `uv build`
- `uv run --no-project --python 3.12 --with pyyaml python -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path("smithery.yaml").read_text())'`
- README, Smithery, and package metadata external link check: active external URLs returned 200. Localhost examples were intentionally skipped.
- `git diff --check`
- Added-line sensitive placeholder scan found only example key names and test placeholders.
- Added concurrency coverage for overlapping Smithery requests with different Xquik keys and base URLs.

Note: `npx --no-install tsc --version` is not available in this zero-dependency repo, so I used the existing Python, build, YAML, and unittest paths for runtime compile/smoke validation instead.
