### PR TITLE
ci: add GitHub Actions (pytest + docker build)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# flyctl launch added from .gitignore
+# Python
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/*.pyd
+**/.Python
+**/env
+**/venv
+**/.venv
+**/*.egg-info
+**/dist
+**/build
+
+# Environment
+**/.env
+
+# Dependency lock files
+**/uv.lock
+
+# IDE
+**/.idea
+
+**/.DS_Store
+fly.toml

--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,10 @@ TWITTER_ACCESS_TOKEN_SECRET="YOUR_ACCESS_TOKEN_SECRET"
 TWITTER_BEARER_TOKEN="YOUR_BEARER_TOKEN"
 # Required for bookmark operations (get_bookmarks, delete_all_bookmarks).
 # Obtain via the PKCE authorization flow using tweepy.OAuth2UserHandler
-# with bookmark.read, bookmark.write, and users.read scopes.
-TWITTER_OAUTH2_USER_ACCESS_TOKEN="YOUR_OAUTH2_USER_ACCESS_TOKEN"
+# with scopes: bookmark.read, bookmark.write, users.read, offline.access.
+# The server refreshes the access token on demand and persists rotated
+# refresh tokens to OAUTH2_STATE_DIR (default /data — mount a Fly volume).
+TWITTER_OAUTH2_USER_REFRESH_TOKEN="YOUR_OAUTH2_USER_REFRESH_TOKEN"
+TWITTER_OAUTH2_CLIENT_ID="YOUR_OAUTH2_CLIENT_ID"
+# Only set for confidential clients (rare for PKCE; leave unset for public clients)
+# TWITTER_OAUTH2_CLIENT_SECRET="YOUR_OAUTH2_CLIENT_SECRET"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev]"
+      - run: python -m pytest
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Builds the actual Fly deploy image from the Dockerfile, with no
+      # secrets. The analog of `wrangler deploy --dry-run`: catches a broken
+      # image / missing dependency before a manual `flyctl deploy`.
+      - run: docker build -t x-twitter-mcp:ci .

--- a/README.md
+++ b/README.md
@@ -152,6 +152,29 @@ Notes:
 - A `POST /` will return 404; use `/mcp` for Streamable HTTP and `/sse` for SSE.
 - When deployed via Smithery, `smithery.yaml` is configured for `runtime: container` and `startCommand.type: http`.
 
+#### Tracing — Fly.io secret rotation
+
+When deploying to Fly with Phoenix Cloud as the tracing backend, set the OTel
+secrets. Phoenix Cloud's auth contract is `authorization: Bearer
+<PHOENIX_API_KEY>` (NOT `api_key=…`) and the wire format is
+OTLP-over-protobuf (JSON returns HTTP 415):
+
+```bash
+fly secrets set \
+  OTEL_EXPORTER_OTLP_ENDPOINT="https://app.phoenix.arize.com/s/<space>/v1/traces" \
+  OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer <PHOENIX_API_KEY>,x-project-name=<project>" \
+  ENVIRONMENT=production \
+  --app x-twitter-mcp
+```
+
+Spans land under `service.name=x-mcp`. Each MCP tool invocation emits an
+`mcp.<tool_name>` span (`mcp.search_twitter`, `mcp.post_tweet`,
+`mcp.get_user_profile`, etc.) with `mcp.tool_name` + `gen_ai.system=x-twitter`
+attributes. If the MCP request carries a `_meta._otel_traceparent` field, the
+tool span nests under that caller's trace; otherwise the span is a synthetic
+root grouped by `service.name`. Skip these vars and the server boots in
+spans-dropped mode — useful for local dev.
+
 ### Streamable HTTP (Local, no Docker)
 Run the ASGI server directly.
 

--- a/fly.toml
+++ b/fly.toml
@@ -29,3 +29,8 @@ kill_timeout = '5s'
   memory = '256mb'
   cpus = 1
   memory_mb = 256
+
+[[mounts]]
+  source = 'twitter_oauth_state'
+  destination = '/data'
+  initial_size = '1'

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,31 @@
+# fly.toml app configuration file generated for x-twitter-mcp on 2026-05-14T15:11:58-07:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'x-twitter-mcp'
+primary_region = 'lax'
+kill_signal = 'SIGINT'
+kill_timeout = '5s'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+[http_service]
+  internal_port = 8081
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+  [http_service.concurrency]
+    type = 'requests'
+    hard_limit = 100
+    soft_limit = 80
+
+[[vm]]
+  size = 'shared-cpu-1x'
+  memory = '256mb'
+  cpus = 1
+  memory_mb = 256

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,18 @@ classifiers = [
 Homepage = "https://github.com/rafaljanicki/x-twitter-mcp-server"
 Issues = "https://github.com/rafaljanicki/x-twitter-mcp-server/issues"
 
+[project.optional-dependencies]
+# Test-only deps. pytest-asyncio is required by tests/test_tracing.py
+# (@pytest.mark.asyncio) but was previously undeclared, so a clean install
+# could not run the suite green. Declared here so CI is reproducible.
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.23",
+]
+
 [project.scripts]
 x-twitter-mcp-server = "x_twitter_mcp:server.run"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,10 @@ dependencies = [
     "tweepy>=4.15.0",
     "python-dotenv>=0.21.0",
     "uvicorn>=0.30.0",
-    "starlette>=0.37.2"
+    "starlette>=0.37.2",
+    "opentelemetry-api>=1.42.0",
+    "opentelemetry-sdk>=1.42.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.42.0"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,9 @@
 fastmcp>=2.2.2
 python-dotenv>=0.21.0
 tweepy>=4.15.0
+# Plan E.x Task 7B / Pattern B — OpenTelemetry export to Phoenix Cloud.
+# OTLP-over-protobuf is mandatory; Phoenix Cloud's CF edge rejects JSON
+# with HTTP 415 (verified on the bridge during Plan E Task 0).
+opentelemetry-api>=1.42.0
+opentelemetry-sdk>=1.42.0
+opentelemetry-exporter-otlp-proto-http>=1.42.0

--- a/src/x_twitter_mcp/http_server.py
+++ b/src/x_twitter_mcp/http_server.py
@@ -10,7 +10,7 @@ from starlette.middleware.cors import CORSMiddleware
 from .server import server
 from .middleware import SmitheryConfigMiddleware
 from .path_token_middleware import from_env as path_token_from_env
-from .tracing import shutdown_tracer_provider
+from .tracing import TraceContextMiddleware, shutdown_tracer_provider
 
 
 def _create_asgi_app() -> Any:
@@ -47,6 +47,11 @@ def _create_asgi_app() -> Any:
         expose_headers=["mcp-session-id", "mcp-protocol-version"],
         max_age=86400,
     )
+
+    # Restore OTel parent context from params._meta._otel_traceparent (JSON
+    # body) or W3C traceparent header before FastMCP strips _meta from
+    # MiddlewareContext (FastMCP 3.3.1 server.py:955).
+    app = TraceContextMiddleware(app)
 
     # Inject Smithery config-per-request and map to env vars used by Tweepy setup
     app = SmitheryConfigMiddleware(app)

--- a/src/x_twitter_mcp/http_server.py
+++ b/src/x_twitter_mcp/http_server.py
@@ -1,4 +1,7 @@
+import atexit
 import os
+import signal
+import sys
 from typing import Any, Callable, Optional
 
 import uvicorn
@@ -7,6 +10,7 @@ from starlette.middleware.cors import CORSMiddleware
 from .server import server
 from .middleware import SmitheryConfigMiddleware
 from .path_token_middleware import from_env as path_token_from_env
+from .tracing import shutdown_tracer_provider
 
 
 def _create_asgi_app() -> Any:
@@ -57,11 +61,25 @@ def _create_asgi_app() -> Any:
 app = _create_asgi_app()
 
 
+def _on_shutdown(*_args: Any) -> None:
+    """Graceful drain — flush in-flight OTel spans before Fly sends SIGKILL.
+
+    Fly's `kill_signal = SIGINT` + `kill_timeout = 5s` gives us a 5s window
+    after SIGINT to land spans in Phoenix. uvicorn's own signal handlers run
+    first and start the graceful shutdown; this hook fires from atexit at
+    the very end of the process lifetime.
+    """
+    shutdown_tracer_provider()
+
+
 def main() -> None:
     """Run the ASGI server using Uvicorn.
 
     Smithery sets PORT; default to 8081 for local testing.
     """
+    atexit.register(_on_shutdown)
+    # Uvicorn installs its own SIGINT/SIGTERM handlers and exits cleanly;
+    # atexit catches every termination path (including SIGTERM via Fly).
     port = int(os.environ.get("PORT", 8081))
     uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
 

--- a/src/x_twitter_mcp/http_server.py
+++ b/src/x_twitter_mcp/http_server.py
@@ -6,6 +6,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from .server import server
 from .middleware import SmitheryConfigMiddleware
+from .path_token_middleware import from_env as path_token_from_env
 
 
 def _create_asgi_app() -> Any:
@@ -45,6 +46,10 @@ def _create_asgi_app() -> Any:
 
     # Inject Smithery config-per-request and map to env vars used by Tweepy setup
     app = SmitheryConfigMiddleware(app)
+
+    # Outermost gate: require MCP_ACCESS_TOKEN as the first path segment.
+    # Refuses to start if the env var is missing — secure by default.
+    app = path_token_from_env()(app)
     return app
 
 

--- a/src/x_twitter_mcp/oauth2_refresh.py
+++ b/src/x_twitter_mcp/oauth2_refresh.py
@@ -1,0 +1,172 @@
+"""OAuth 2.0 user-token refresh for the Twitter/X bookmarks endpoints.
+
+Twitter access tokens issued via the OAuth 2.0 PKCE flow expire after
+~2 hours. The refresh token (granted by the `offline.access` scope) is
+single-use: each refresh response includes a new refresh_token and the
+old one is revoked.
+
+This machine runs with `auto_stop_machines='stop'`, so in-memory state
+is lost between requests. Rotated refresh tokens are persisted to a
+Fly volume at `OAUTH2_STATE_DIR` (defaults to `/data`). The first
+refresh after a deploy uses the `TWITTER_OAUTH2_USER_REFRESH_TOKEN`
+env var as bootstrap; subsequent refreshes read from the volume.
+
+Added by Dreamware Development. Not part of the upstream
+rafaljanicki/x-twitter-mcp-server distribution.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from threading import Lock
+from typing import Optional
+
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_ENDPOINT = "https://api.twitter.com/2/oauth2/token"
+_REQUEST_TIMEOUT = 30
+_EXPIRY_SKEW_SECONDS = 60
+
+_STATE_DIR = Path(os.environ.get("OAUTH2_STATE_DIR", "/data"))
+_REFRESH_TOKEN_FILE = _STATE_DIR / "twitter_oauth2_refresh_token"
+_ACCESS_TOKEN_CACHE = _STATE_DIR / "twitter_oauth2_access_token.json"
+
+_lock = Lock()
+
+
+def _load_refresh_token() -> str:
+    if _REFRESH_TOKEN_FILE.exists():
+        try:
+            token = _REFRESH_TOKEN_FILE.read_text().strip()
+            if token:
+                return token
+        except OSError as exc:
+            logger.warning("Failed reading persisted refresh token (%s); falling back to env", exc)
+
+    env_token = os.environ.get("TWITTER_OAUTH2_USER_REFRESH_TOKEN", "").strip()
+    if not env_token:
+        raise EnvironmentError(
+            "No OAuth 2.0 refresh token available. Set the Fly secret "
+            "TWITTER_OAUTH2_USER_REFRESH_TOKEN as a bootstrap, and ensure "
+            f"{_STATE_DIR} is a mounted Fly volume so rotated tokens persist."
+        )
+    return env_token
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content)
+    os.chmod(tmp, 0o600)
+    tmp.replace(path)
+
+
+def _persist_refresh_token(token: str) -> None:
+    try:
+        _atomic_write(_REFRESH_TOKEN_FILE, token)
+        logger.info("Persisted rotated refresh token to %s", _REFRESH_TOKEN_FILE)
+    except OSError as exc:
+        logger.error(
+            "FAILED to persist rotated refresh token to %s: %s. "
+            "The next cold start will read the stale bootstrap secret and "
+            "the refresh will fail with invalid_grant. Update the Fly secret "
+            "TWITTER_OAUTH2_USER_REFRESH_TOKEN manually to recover.",
+            _REFRESH_TOKEN_FILE,
+            exc,
+        )
+
+
+def _load_cached_access_token() -> Optional[str]:
+    if not _ACCESS_TOKEN_CACHE.exists():
+        return None
+    try:
+        data = json.loads(_ACCESS_TOKEN_CACHE.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Cached access token unreadable (%s); will refresh", exc)
+        return None
+    token = data.get("access_token")
+    expires_at = float(data.get("expires_at", 0))
+    if not token or expires_at <= time.time() + _EXPIRY_SKEW_SECONDS:
+        return None
+    return token
+
+
+def _persist_access_token(token: str, expires_at: float) -> None:
+    try:
+        _atomic_write(
+            _ACCESS_TOKEN_CACHE,
+            json.dumps({"access_token": token, "expires_at": expires_at}),
+        )
+    except OSError as exc:
+        logger.warning("Failed to cache access token (%s); refresh will repeat next request", exc)
+
+
+def _do_refresh(refresh_token: str) -> tuple[str, str, float]:
+    client_id = os.environ.get("TWITTER_OAUTH2_CLIENT_ID")
+    if not client_id:
+        raise EnvironmentError(
+            "TWITTER_OAUTH2_CLIENT_ID is required to refresh the OAuth 2.0 user token. "
+            "Set it to your Twitter app's OAuth 2.0 Client ID (Developer Portal → "
+            "your app → Keys and tokens → OAuth 2.0 Client ID and Client Secret)."
+        )
+    client_secret = os.environ.get("TWITTER_OAUTH2_CLIENT_SECRET")
+
+    data = {
+        "refresh_token": refresh_token,
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+    }
+    auth = (client_id, client_secret) if client_secret else None
+
+    resp = requests.post(
+        _TOKEN_ENDPOINT,
+        data=data,
+        auth=auth,
+        timeout=_REQUEST_TIMEOUT,
+        headers={"Accept": "application/json"},
+    )
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Twitter OAuth 2.0 refresh failed ({resp.status_code}): {resp.text}"
+        )
+
+    payload = resp.json()
+    access_token = payload["access_token"]
+    new_refresh_token = payload.get("refresh_token", refresh_token)
+    expires_in = float(payload.get("expires_in", 7200))
+    expires_at = time.time() + expires_in
+    return access_token, new_refresh_token, expires_at
+
+
+def get_access_token(force_refresh: bool = False) -> str:
+    """Return a valid OAuth 2.0 user access token, refreshing if needed.
+
+    Args:
+        force_refresh: If True, ignore the cached access token and refresh
+            unconditionally. Used after a 401 from a bookmarks API call to
+            cover the case where Twitter invalidated the token early.
+    """
+    with _lock:
+        if not force_refresh:
+            cached = _load_cached_access_token()
+            if cached:
+                return cached
+
+        refresh_token = _load_refresh_token()
+        access_token, new_refresh_token, expires_at = _do_refresh(refresh_token)
+
+        if new_refresh_token != refresh_token:
+            _persist_refresh_token(new_refresh_token)
+        _persist_access_token(access_token, expires_at)
+        logger.info(
+            "Refreshed OAuth 2.0 access token (expires in %.0fs)",
+            expires_at - time.time(),
+        )
+        return access_token

--- a/src/x_twitter_mcp/path_token_middleware.py
+++ b/src/x_twitter_mcp/path_token_middleware.py
@@ -1,0 +1,77 @@
+"""Path-token auth middleware for x-twitter-mcp-server.
+
+Validates that the first segment of the request path matches the
+MCP_ACCESS_TOKEN env var. Strips the token from the path before
+forwarding to the underlying ASGI app, so downstream routes still
+match (/mcp, /sse).
+
+Added by Dreamware Development for Fly.io deployment. Not part of
+the upstream rafaljanicki/x-twitter-mcp-server distribution.
+"""
+
+import hmac
+import os
+from typing import Any, Awaitable, Callable
+
+from starlette.responses import PlainTextResponse
+
+
+Receive = Callable[[], Awaitable[dict]]
+Send = Callable[[dict], Awaitable[None]]
+
+
+class PathTokenMiddleware:
+    """ASGI middleware that requires the first path segment to be a secret token.
+
+    URL shape expected by claude.ai custom connector:
+        https://<host>/<MCP_ACCESS_TOKEN>/mcp
+
+    Requests without a matching first segment receive 401 Unauthorized
+    and never reach the underlying MCP server.
+    """
+
+    def __init__(self, app: Any, token: str) -> None:
+        if not token:
+            raise RuntimeError(
+                "PathTokenMiddleware requires a non-empty token. "
+                "Set MCP_ACCESS_TOKEN to a long random string (e.g. `openssl rand -hex 32`)."
+            )
+        self.app = app
+        self._token = token
+
+    async def __call__(self, scope: dict, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "/")
+        parts = path.lstrip("/").split("/", 1)
+        first_segment = parts[0] if parts else ""
+
+        if not first_segment or not hmac.compare_digest(first_segment, self._token):
+            response = PlainTextResponse("Unauthorized", status_code=401)
+            await response(scope, receive, send)
+            return
+
+        # Rewrite scope to drop the token from path + raw_path.
+        new_path = "/" + (parts[1] if len(parts) > 1 else "")
+        new_scope = {
+            **scope,
+            "path": new_path,
+            "raw_path": new_path.encode("utf-8"),
+        }
+        await self.app(new_scope, receive, send)
+
+
+def from_env() -> "Callable[[Any], PathTokenMiddleware]":
+    """Factory that reads MCP_ACCESS_TOKEN at app-build time.
+
+    Raises at startup if the token is missing — the server refuses to
+    boot rather than expose tools without auth.
+    """
+    token = os.environ.get("MCP_ACCESS_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "MCP_ACCESS_TOKEN env var is required. Set it via `fly secrets set MCP_ACCESS_TOKEN=$(openssl rand -hex 32)`."
+        )
+    return lambda app: PathTokenMiddleware(app, token)

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -10,6 +10,7 @@ from typing import List, Dict, Optional
 from dotenv import load_dotenv
 
 from . import oauth2_refresh
+from .tracing import TracingMiddleware, init_tracer_provider
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -20,8 +21,21 @@ warnings.filterwarnings("ignore", category=SyntaxWarning)
 # Load environment variables from .env file (if present)
 load_dotenv()
 
+# Initialize the OpenTelemetry tracer provider before the FastMCP server so
+# its tools-call dispatch has a registered tracer to ask for. When the OTLP
+# env vars are unset the provider falls into no-op mode — safe to leave on
+# in all environments (stdio mode, http mode, tests).
+init_tracer_provider()
+
 # Initialize FastMCP server
 server = FastMCP(name="TwitterMCPServer")
+
+# Plan E.x Task 7B / Pattern B — wrap every tools/call in an
+# `mcp.<tool_name>` span. The middleware also restores a parent traceparent
+# from `params._meta._otel_traceparent` so the spans nest under the caller's
+# trace when one is supplied (orphan-rooted under service.name=x-mcp
+# otherwise — still groupable in Phoenix).
+server.add_middleware(TracingMiddleware())
 
 # Twitter API client setup (lazy-loaded)
 _twitter_client = None

--- a/src/x_twitter_mcp/server.py
+++ b/src/x_twitter_mcp/server.py
@@ -9,6 +9,8 @@ from datetime import datetime, timedelta
 from typing import List, Dict, Optional
 from dotenv import load_dotenv
 
+from . import oauth2_refresh
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -67,49 +69,65 @@ def initialize_twitter_clients() -> tuple[tweepy.Client, tweepy.API]:
 _API_TIMEOUT = 30  # seconds
 
 
-def _get_oauth2_headers_and_user_id() -> tuple[dict, str]:
-    """Resolve OAuth 2.0 Authorization headers and the authenticated user ID.
+class _OAuth2Session:
+    """Bundles the current access token, auth headers, and authenticated user ID.
 
-    The bookmarks endpoint (/2/users/:id/bookmarks) requires OAuth 2.0 User
-    Context — it rejects both app-only bearer tokens and OAuth 1.0a.
-
-    Set TWITTER_OAUTH2_USER_ACCESS_TOKEN to the token obtained via the PKCE
-    authorization flow (tweepy.OAuth2UserHandler) with bookmark.read,
-    bookmark.write, and users.read scopes.
-
-    Returns:
-        A (headers, user_id) tuple. Call once per operation and reuse across
-        multiple requests to avoid redundant /2/users/me lookups.
+    The token may be rotated mid-session if Twitter returns 401 — call
+    `force_refresh()` to swap in a freshly minted token and update headers.
     """
-    token = os.getenv("TWITTER_OAUTH2_USER_ACCESS_TOKEN")
-    if not token:
-        raise EnvironmentError(
-            "Missing required environment variable: TWITTER_OAUTH2_USER_ACCESS_TOKEN. "
-            "Obtain one via the PKCE authorization flow (tweepy.OAuth2UserHandler) "
-            "with bookmark.read, bookmark.write, and users.read scopes."
+
+    def __init__(self) -> None:
+        self.access_token = oauth2_refresh.get_access_token()
+        self.headers = {"Authorization": f"Bearer {self.access_token}"}
+        me = requests.get(
+            "https://api.twitter.com/2/users/me",
+            headers=self.headers,
+            timeout=_API_TIMEOUT,
         )
-    headers = {"Authorization": f"Bearer {token}"}
-    me = requests.get("https://api.twitter.com/2/users/me", headers=headers, timeout=_API_TIMEOUT)
-    me.raise_for_status()
-    return headers, me.json()["data"]["id"]
+        if me.status_code == 401:
+            self.force_refresh()
+            me = requests.get(
+                "https://api.twitter.com/2/users/me",
+                headers=self.headers,
+                timeout=_API_TIMEOUT,
+            )
+        me.raise_for_status()
+        self.user_id = me.json()["data"]["id"]
+
+    def force_refresh(self) -> None:
+        self.access_token = oauth2_refresh.get_access_token(force_refresh=True)
+        self.headers = {"Authorization": f"Bearer {self.access_token}"}
 
 
-def _bookmarks_request(method: str, headers: dict, user_id: str,
+def _bookmarks_request(method: str, session: "_OAuth2Session",
                        tweet_id: Optional[str] = None,
                        params: Optional[dict] = None) -> dict:
-    """Make a single bookmark API request.
+    """Make a single bookmark API request, refreshing the token once on 401.
 
     Args:
         method: HTTP method ("GET" or "DELETE").
-        headers: Authorization headers from _get_oauth2_headers_and_user_id().
-        user_id: Authenticated user's ID.
+        session: OAuth 2.0 session carrying the access token, headers, and user ID.
         tweet_id: Tweet ID appended to the URL for DELETE requests.
         params: Query parameters for GET requests.
     """
-    url = f"https://api.twitter.com/2/users/{user_id}/bookmarks"
+    url = f"https://api.twitter.com/2/users/{session.user_id}/bookmarks"
     if tweet_id:
         url += f"/{tweet_id}"
-    resp = requests.request(method, url, headers=headers, params=params or {}, timeout=_API_TIMEOUT)
+
+    def _send() -> requests.Response:
+        return requests.request(
+            method,
+            url,
+            headers=session.headers,
+            params=params or {},
+            timeout=_API_TIMEOUT,
+        )
+
+    resp = _send()
+    if resp.status_code == 401:
+        logger.info("Bookmark request returned 401; forcing OAuth 2.0 refresh and retrying once")
+        session.force_refresh()
+        resp = _send()
     resp.raise_for_status()
     return resp.json()
 
@@ -395,14 +413,14 @@ async def delete_all_bookmarks() -> Dict:
         raise Exception("Tweet action rate limit exceeded")
     # Twitter API v2 doesn't have a bulk-delete endpoint; fetch all pages and
     # remove bookmarks one by one. Both fetch and delete require OAuth 2.0.
-    headers, user_id = _get_oauth2_headers_and_user_id()
+    session = _OAuth2Session()
     deleted = 0
     next_token = None
     while True:
         params: dict = {"max_results": 100}
         if next_token:
             params["pagination_token"] = next_token
-        data = _bookmarks_request("GET", headers, user_id, params=params)
+        data = _bookmarks_request("GET", session, params=params)
         tweets = data.get("data", [])
         if not tweets:
             break
@@ -411,7 +429,7 @@ async def delete_all_bookmarks() -> Dict:
                 raise Exception(
                     f"Tweet action rate limit exceeded after deleting {deleted} bookmarks"
                 )
-            _bookmarks_request("DELETE", headers, user_id, tweet_id=tweet["id"])
+            _bookmarks_request("DELETE", session, tweet_id=tweet["id"])
             deleted += 1
         next_token = data.get("meta", {}).get("next_token")
         if not next_token:
@@ -422,9 +440,11 @@ async def delete_all_bookmarks() -> Dict:
 async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None) -> List[Dict]:
     """Fetches the authenticated user's bookmarked tweets.
 
-    Requires TWITTER_OAUTH2_USER_ACCESS_TOKEN — a user-scoped OAuth 2.0 token
-    obtained via the PKCE authorization flow with bookmark.read and users.read
-    scopes.
+    Requires the OAuth 2.0 refresh flow to be configured:
+    TWITTER_OAUTH2_USER_REFRESH_TOKEN (from a PKCE flow with bookmark.read,
+    bookmark.write, users.read, and offline.access scopes) plus
+    TWITTER_OAUTH2_CLIENT_ID. The server refreshes the access token on demand
+    and persists rotated refresh tokens to the Fly volume at /data.
 
     Args:
         count (Optional[int]): Number of bookmarks to retrieve per page.
@@ -442,14 +462,14 @@ async def get_bookmarks(count: Optional[int] = 100, cursor: Optional[str] = None
         effective_count = 100
     else:
         effective_count = count
-    headers, user_id = _get_oauth2_headers_and_user_id()
+    session = _OAuth2Session()
     params: dict = {
         "max_results": effective_count,
         "tweet.fields": "id,text,created_at,author_id",
     }
     if cursor:
         params["pagination_token"] = cursor
-    data = _bookmarks_request("GET", headers, user_id, params=params)
+    data = _bookmarks_request("GET", session, params=params)
     return data.get("data", [])
 
 # Timeline & Search Tools

--- a/src/x_twitter_mcp/tracing.py
+++ b/src/x_twitter_mcp/tracing.py
@@ -1,0 +1,323 @@
+"""OpenTelemetry tracing for the X (Twitter) MCP server.
+
+Plan E.x Task 7B, Pattern B — server-side instrumentation. Each MCP
+`tools/call` request emits an `mcp.<tool_name>` span; the resulting traces
+land in Phoenix Cloud under ``service.name=x-mcp``.
+
+Wire format notes (verified during the bridge's Plan E Task 0):
+  * Phoenix Cloud's CF edge rejects ``application/json`` with HTTP 415.
+    Only OTLP-over-protobuf is accepted, so we use
+    ``opentelemetry-exporter-otlp-proto-http``.
+  * Auth contract: ``authorization: Bearer <PHOENIX_API_KEY>`` (NOT
+    ``api_key=…``) per Arize-ai/phoenix packages/phoenix-otel/otel.py:169.
+  * Project routing: ``x-project-name: <project>`` (Arize 2026-05-08 release).
+
+Context propagation: Python's contextvars give us automatic async propagation
+across awaits — unlike the Cloudflare Workers side of the bridge, no
+custom context manager registration is required. The OTel SDK's
+``contextvars_context.ContextVarsRuntimeContext`` is the default.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from typing import Any
+
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import SpanKind, Status, StatusCode, TraceFlags
+
+logger = logging.getLogger(__name__)
+
+SERVICE_NAME = "x-mcp"
+SERVICE_VERSION = "0.1.15"
+TRACER_NAME = "x-twitter-mcp-server"
+
+_TRACEPARENT_RE = re.compile(r"^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$")
+
+_provider: TracerProvider | None = None
+
+
+def _parse_otlp_headers(raw: str) -> dict[str, str]:
+    """Parse OTEL_EXPORTER_OTLP_HEADERS (comma-separated key=value).
+
+    Values may contain ``=`` (e.g. base64 in a Bearer token), so we split
+    on the first ``=`` only.
+    """
+    out: dict[str, str] = {}
+    for pair in raw.split(","):
+        if not pair.strip():
+            continue
+        key, _, value = pair.partition("=")
+        out[key.strip()] = value.strip()
+    return out
+
+
+def _parse_resource_attrs(raw: str | None) -> dict[str, str]:
+    """Parse the OTel-standard OTEL_RESOURCE_ATTRIBUTES env var.
+
+    Format: comma-separated ``key=value`` pairs. We mirror
+    ``_parse_otlp_headers`` (first-``=`` split) so values containing ``=``
+    survive unmangled.
+    """
+    if not raw:
+        return {}
+    out: dict[str, str] = {}
+    for pair in raw.split(","):
+        if not pair.strip():
+            continue
+        key, _, value = pair.partition("=")
+        out[key.strip()] = value.strip()
+    return out
+
+
+def init_tracer_provider() -> TracerProvider:
+    """Idempotent tracer-provider init.
+
+    When ``OTEL_EXPORTER_OTLP_ENDPOINT`` or ``OTEL_EXPORTER_OTLP_HEADERS`` is
+    unset, returns a no-op provider so the MCP server still boots in local
+    dev and on Fly machines before secrets land. Spans created against the
+    no-op provider are silently dropped — zero overhead.
+
+    Returns the singleton provider; safe to call repeatedly.
+    """
+    global _provider
+    if _provider is not None:
+        return _provider
+
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    headers = os.environ.get("OTEL_EXPORTER_OTLP_HEADERS")
+    environment = os.environ.get("ENVIRONMENT", "unknown")
+
+    # Resource precedence: hardcoded defaults → OTEL_RESOURCE_ATTRIBUTES →
+    # OTEL_SERVICE_NAME (highest). Reading env vars manually rather than
+    # relying on Resource.create's detector aggregation because the SDK's
+    # detector merge inverts what we want: passing attrs to Resource.create
+    # makes them override env, but operators set env to override code defaults.
+    attrs: dict[str, str] = {
+        "service.name": SERVICE_NAME,
+        "service.version": SERVICE_VERSION,
+        "deployment.environment": environment,
+    }
+    attrs.update(_parse_resource_attrs(os.environ.get("OTEL_RESOURCE_ATTRIBUTES")))
+    env_service_name = os.environ.get("OTEL_SERVICE_NAME")
+    if env_service_name:
+        attrs["service.name"] = env_service_name
+
+    resource = Resource(attrs)
+
+    if not endpoint or not headers:
+        logger.warning(
+            "tracing: OTEL_EXPORTER_OTLP_{ENDPOINT,HEADERS} unset; spans dropped"
+        )
+        _provider = TracerProvider(resource=resource)
+        trace.set_tracer_provider(_provider)
+        return _provider
+
+    exporter = OTLPSpanExporter(
+        endpoint=endpoint,
+        headers=_parse_otlp_headers(headers),
+    )
+    _provider = TracerProvider(resource=resource)
+    _provider.add_span_processor(
+        BatchSpanProcessor(
+            exporter,
+            max_queue_size=256,
+            max_export_batch_size=32,
+            schedule_delay_millis=1000,
+            export_timeout_millis=5000,
+        )
+    )
+    trace.set_tracer_provider(_provider)
+    logger.info(
+        "tracing: OTel provider initialized (service=%s env=%s endpoint=%s)",
+        SERVICE_NAME,
+        environment,
+        endpoint,
+    )
+    return _provider
+
+
+def shutdown_tracer_provider() -> None:
+    """Flush and shut down the provider — called on process termination so
+    in-flight spans land in Phoenix before Fly sends SIGKILL.
+    """
+    global _provider
+    if _provider is None:
+        return
+    try:
+        _provider.force_flush(timeout_millis=4500)
+        _provider.shutdown()
+    except Exception as exc:  # pragma: no cover - best effort on shutdown
+        logger.warning("tracing: shutdown error (ignored): %s", exc)
+
+
+def parse_traceparent(header: str | None) -> trace.SpanContext | None:
+    """Parse a W3C traceparent header into a SpanContext.
+
+    Returns ``None`` for malformed or missing input — the caller should fall
+    back to the current active context.
+    """
+    if not header:
+        return None
+    match = _TRACEPARENT_RE.match(header)
+    if not match:
+        return None
+    trace_id = int(match.group(1), 16)
+    span_id = int(match.group(2), 16)
+    flags = int(match.group(3), 16)
+    return trace.SpanContext(
+        trace_id=trace_id,
+        span_id=span_id,
+        is_remote=True,
+        trace_flags=TraceFlags(flags),
+    )
+
+
+def restore_parent_context(traceparent: str | None) -> Context:
+    """Restore an OTel Context from a traceparent header string.
+
+    Returns the current active context when traceparent is missing or
+    malformed — so a missing parent doesn't break the trace, it just makes
+    the child span a synthetic root grouped by ``service.name=x-mcp``.
+    """
+    span_ctx = parse_traceparent(traceparent)
+    if span_ctx is None:
+        return otel_context.get_current()
+    return trace.set_span_in_context(trace.NonRecordingSpan(span_ctx))
+
+
+def extract_traceparent_from_meta(meta: Any) -> str | None:
+    """Pull ``_otel_traceparent`` out of an MCP request's ``params._meta``.
+
+    The MCP ``RequestParams.Meta`` model has ``extra="allow"``, so Pydantic
+    parses ``{"_otel_traceparent": "..."}`` into the model but exposes it via
+    ``model_extra`` or as a regular attribute on the parsed instance. We
+    accept both shapes (Pydantic-model and bare dict) defensively because
+    middleware sometimes sees pre-validation payloads.
+    """
+    if meta is None:
+        return None
+    # Pydantic v2 model — use model_extra, falling back to getattr for typed
+    # fields that might be promoted to first-class in a future MCP schema.
+    extras = getattr(meta, "model_extra", None)
+    if isinstance(extras, dict):
+        value = extras.get("_otel_traceparent")
+        if isinstance(value, str):
+            return value
+    value = getattr(meta, "_otel_traceparent", None)
+    if isinstance(value, str):
+        return value
+    if isinstance(meta, dict):
+        value = meta.get("_otel_traceparent")
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def get_tracer() -> trace.Tracer:
+    """Return the project tracer. Triggers lazy init when called before the
+    HTTP entrypoint (defensive — e.g. from stdio mode or a unit test)."""
+    if _provider is None:
+        init_tracer_provider()
+    return trace.get_tracer(TRACER_NAME)
+
+
+class TracingMiddleware:
+    """FastMCP middleware that opens an ``mcp.<tool_name>`` span around each
+    ``tools/call`` and restores a parent traceparent if the caller injected
+    one into ``params._meta._otel_traceparent``.
+
+    The class is duck-typed against ``fastmcp.server.middleware.Middleware``
+    rather than subclassing it, so this module stays import-safe even when
+    FastMCP's middleware API shifts between minor versions (the surface we
+    use is ``on_call_tool(context, call_next)`` plus ``__call__`` dispatch).
+    """
+
+    def __init__(self) -> None:
+        # Import here to defer the FastMCP dep — keeps `import tracing` cheap
+        # for tests that just want parse_traceparent.
+        from fastmcp.server.middleware import Middleware  # noqa: F401  (typecheck only)
+
+    async def __call__(self, context: Any, call_next: Any) -> Any:
+        # Delegate to FastMCP's built-in dispatch (which routes to on_call_tool
+        # for tools/call, on_request for others) by mirroring the parent class
+        # behaviour. We override only on_call_tool below.
+        from fastmcp.server.middleware import Middleware
+
+        return await Middleware.__call__(self, context, call_next)  # type: ignore[arg-type]
+
+    # The parent class's __call__ delegates by method name. on_call_tool is
+    # invoked for `tools/call` requests; everything else passes through.
+    async def on_call_tool(self, context: Any, call_next: Any) -> Any:
+        params = getattr(context, "message", None)
+        tool_name = getattr(params, "name", "unknown") if params is not None else "unknown"
+        meta = getattr(params, "meta", None) if params is not None else None
+        traceparent = extract_traceparent_from_meta(meta)
+
+        parent_ctx = restore_parent_context(traceparent)
+        tracer = get_tracer()
+        span = tracer.start_span(
+            f"mcp.{tool_name}",
+            context=parent_ctx,
+            kind=SpanKind.SERVER,
+            attributes={
+                "mcp.tool_name": tool_name,
+                "gen_ai.system": "x-twitter",
+            },
+        )
+        active_ctx = trace.set_span_in_context(span, parent_ctx)
+        token = otel_context.attach(active_ctx)
+        try:
+            result = await call_next(context)
+            span.set_status(Status(StatusCode.OK))
+            return result
+        except Exception as exc:
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise
+        finally:
+            otel_context.detach(token)
+            span.end()
+
+    # Pass-through for every other middleware hook so unhandled message
+    # types reach `call_next` unmodified. FastMCP's Middleware base provides
+    # these as no-ops; defining them locally would shadow that — leave the
+    # base class to handle them via __call__'s _dispatch_handler.
+
+    async def on_message(self, context: Any, call_next: Any) -> Any:
+        return await call_next(context)
+
+    async def on_request(self, context: Any, call_next: Any) -> Any:
+        return await call_next(context)
+
+    async def on_notification(self, context: Any, call_next: Any) -> Any:
+        return await call_next(context)
+
+    async def on_initialize(self, context: Any, call_next: Any) -> Any:
+        return await call_next(context)
+
+    async def on_list_tools(self, context: Any, call_next: Any) -> Any:
+        return await call_next(context)
+
+    async def on_read_resource(self, context: Any, call_next: Any) -> Any:
+        return await call_next(context)
+
+    async def on_get_prompt(self, context: Any, call_next: Any) -> Any:
+        return await call_next(context)
+
+    async def on_list_resources(self, context: Any, call_next: Any) -> Any:
+        return await call_next(context)
+
+    async def on_list_resource_templates(self, context: Any, call_next: Any) -> Any:
+        return await call_next(context)
+
+    async def on_list_prompts(self, context: Any, call_next: Any) -> Any:
+        return await call_next(context)

--- a/src/x_twitter_mcp/tracing.py
+++ b/src/x_twitter_mcp/tracing.py
@@ -310,9 +310,16 @@ class TraceContextMiddleware:
 
 class TracingMiddleware(Middleware):
     """FastMCP middleware that opens an ``mcp.<tool_name>`` span around each
-    ``tools/call``. Parent context is picked up from the active OTel context,
-    which ``TraceContextMiddleware`` sets at the HTTP layer by restoring the
-    traceparent injected into ``params._meta._otel_traceparent``.
+    ``tools/call``.
+
+    Parent context is read from the MCP SDK's ``request_ctx`` ContextVar, which
+    the MCP SDK sets (with the original ``params._meta``) inside the session
+    server task right before dispatching to any handler.  This bypasses the
+    FastMCP 3.3.1 server.py:955 bug where ``CallToolRequestParams`` is
+    reconstructed without ``_meta``, and also crosses the asyncio task
+    boundary created by ``StreamableHTTPSessionManager`` for stateful sessions
+    (where setting OTel context at the HTTP layer has no effect because the
+    server task was created during a prior request).
     """
 
     # on_call_tool is invoked for `tools/call` requests; everything else
@@ -321,7 +328,18 @@ class TracingMiddleware(Middleware):
         params = getattr(context, "message", None)
         tool_name = getattr(params, "name", "unknown") if params is not None else "unknown"
 
-        parent_ctx = otel_context.get_current()
+        # Read the original _meta that the MCP SDK stored in request_ctx.
+        # Falls back to current OTel context (a synthetic root) if request_ctx
+        # is not set (e.g. in unit tests or stateless mode pre-initialization).
+        traceparent: str | None = None
+        try:
+            from mcp.server.lowlevel.server import request_ctx as _mcp_request_ctx
+
+            traceparent = extract_traceparent_from_meta(_mcp_request_ctx.get().meta)
+        except Exception:
+            pass
+
+        parent_ctx = restore_parent_context(traceparent)
         tracer = get_tracer()
         span = tracer.start_span(
             f"mcp.{tool_name}",

--- a/src/x_twitter_mcp/tracing.py
+++ b/src/x_twitter_mcp/tracing.py
@@ -20,6 +20,7 @@ custom context manager registration is required. The OTel SDK's
 
 from __future__ import annotations
 
+import json as _json
 import logging
 import os
 import re
@@ -231,10 +232,87 @@ def get_tracer() -> trace.Tracer:
     return trace.get_tracer(TRACER_NAME)
 
 
+class TraceContextMiddleware:
+    """ASGI middleware that restores an OTel parent context from the MCP JSON
+    request body or the W3C ``traceparent`` HTTP header before FastMCP sees it.
+
+    FastMCP 3.3.1 strips ``params._meta`` in its middleware layer (server.py
+    line 955: CallToolRequestParams is reconstructed without _meta), so the
+    only reliable injection point is the raw HTTP body, before FastMCP parses
+    it.
+
+    Priority:
+      1. ``params._meta._otel_traceparent`` in JSON body (Worker injection)
+      2. W3C ``traceparent`` HTTP request header (standard propagation)
+      3. Active context — span becomes a synthetic root, no error
+    """
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Buffer the full request body once so we can inspect it AND replay
+        # it for FastMCP, which reads it a second time over the ASGI channel.
+        chunks: list[bytes] = []
+        while True:
+            msg = await receive()
+            chunks.append(msg.get("body", b""))
+            if not msg.get("more_body", False):
+                break
+        body = b"".join(chunks)
+
+        traceparent: str | None = None
+
+        # Try JSON body first (MCP injection by the bridge Worker).
+        try:
+            if body:
+                payload = _json.loads(body)
+                if isinstance(payload, dict):
+                    params = payload.get("params")
+                    if isinstance(params, dict):
+                        meta = params.get("_meta")
+                        if isinstance(meta, dict):
+                            tp = meta.get("_otel_traceparent")
+                            if isinstance(tp, str):
+                                traceparent = tp
+        except Exception:
+            pass
+
+        # Fall back to the W3C traceparent request header.
+        if traceparent is None:
+            for k, v in scope.get("headers", []):
+                if k.lower() == b"traceparent":
+                    traceparent = v.decode("ascii", errors="replace")
+                    break
+
+        parent_ctx = restore_parent_context(traceparent)
+        token = otel_context.attach(parent_ctx)
+
+        # Replay the buffered body to the downstream ASGI app.
+        replayed = False
+
+        async def replay_receive() -> dict[str, Any]:
+            nonlocal replayed
+            if not replayed:
+                replayed = True
+                return {"type": "http.request", "body": body, "more_body": False}
+            return {"type": "http.disconnect"}
+
+        try:
+            await self.app(scope, replay_receive, send)
+        finally:
+            otel_context.detach(token)
+
+
 class TracingMiddleware(Middleware):
     """FastMCP middleware that opens an ``mcp.<tool_name>`` span around each
-    ``tools/call`` and restores a parent traceparent if the caller injected
-    one into ``params._meta._otel_traceparent``.
+    ``tools/call``. Parent context is picked up from the active OTel context,
+    which ``TraceContextMiddleware`` sets at the HTTP layer by restoring the
+    traceparent injected into ``params._meta._otel_traceparent``.
     """
 
     # on_call_tool is invoked for `tools/call` requests; everything else
@@ -242,10 +320,8 @@ class TracingMiddleware(Middleware):
     async def on_call_tool(self, context: Any, call_next: Any) -> Any:
         params = getattr(context, "message", None)
         tool_name = getattr(params, "name", "unknown") if params is not None else "unknown"
-        meta = getattr(params, "meta", None) if params is not None else None
-        traceparent = extract_traceparent_from_meta(meta)
 
-        parent_ctx = restore_parent_context(traceparent)
+        parent_ctx = otel_context.get_current()
         tracer = get_tracer()
         span = tracer.start_span(
             f"mcp.{tool_name}",

--- a/src/x_twitter_mcp/tracing.py
+++ b/src/x_twitter_mcp/tracing.py
@@ -25,6 +25,7 @@ import os
 import re
 from typing import Any
 
+from fastmcp.server.middleware import Middleware
 from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.context import Context
@@ -230,32 +231,14 @@ def get_tracer() -> trace.Tracer:
     return trace.get_tracer(TRACER_NAME)
 
 
-class TracingMiddleware:
+class TracingMiddleware(Middleware):
     """FastMCP middleware that opens an ``mcp.<tool_name>`` span around each
     ``tools/call`` and restores a parent traceparent if the caller injected
     one into ``params._meta._otel_traceparent``.
-
-    The class is duck-typed against ``fastmcp.server.middleware.Middleware``
-    rather than subclassing it, so this module stays import-safe even when
-    FastMCP's middleware API shifts between minor versions (the surface we
-    use is ``on_call_tool(context, call_next)`` plus ``__call__`` dispatch).
     """
 
-    def __init__(self) -> None:
-        # Import here to defer the FastMCP dep — keeps `import tracing` cheap
-        # for tests that just want parse_traceparent.
-        from fastmcp.server.middleware import Middleware  # noqa: F401  (typecheck only)
-
-    async def __call__(self, context: Any, call_next: Any) -> Any:
-        # Delegate to FastMCP's built-in dispatch (which routes to on_call_tool
-        # for tools/call, on_request for others) by mirroring the parent class
-        # behaviour. We override only on_call_tool below.
-        from fastmcp.server.middleware import Middleware
-
-        return await Middleware.__call__(self, context, call_next)  # type: ignore[arg-type]
-
-    # The parent class's __call__ delegates by method name. on_call_tool is
-    # invoked for `tools/call` requests; everything else passes through.
+    # on_call_tool is invoked for `tools/call` requests; everything else
+    # passes through via the Middleware base class dispatch.
     async def on_call_tool(self, context: Any, call_next: Any) -> Any:
         params = getattr(context, "message", None)
         tool_name = getattr(params, "name", "unknown") if params is not None else "unknown"

--- a/src/x_twitter_mcp/tracing.py
+++ b/src/x_twitter_mcp/tracing.py
@@ -292,7 +292,20 @@ class TraceContextMiddleware:
         parent_ctx = restore_parent_context(traceparent)
         token = otel_context.attach(parent_ctx)
 
-        # Replay the buffered body to the downstream ASGI app.
+        # Replay the buffered body to the downstream ASGI app, then delegate
+        # subsequent receive() calls to the underlying receive callable.
+        #
+        # FastMCP's streamable_http transport calls receive() a second time
+        # inside its response handler to watch for client disconnects mid-SSE.
+        # Returning a synthetic http.disconnect on the second call (the prior
+        # behavior) tricked FastMCP into aborting the response before sending
+        # the final body chunk — uvicorn then logged "ASGI callable returned
+        # without completing response" and Fly's proxy reported "could not
+        # finish reading HTTP body from instance", which Anthropic Managed
+        # Agents interpreted as "MCP server 'x' initialize failed: protocol
+        # error". Delegating to the real receive preserves the natural
+        # disconnect semantics: it blocks until the actual client drops, exactly
+        # what FastMCP needs.
         replayed = False
 
         async def replay_receive() -> dict[str, Any]:
@@ -300,7 +313,7 @@ class TraceContextMiddleware:
             if not replayed:
                 replayed = True
                 return {"type": "http.request", "body": body, "more_body": False}
-            return {"type": "http.disconnect"}
+            return await receive()
 
         try:
             await self.app(scope, replay_receive, send)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import pytest
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
@@ -32,6 +33,7 @@ _PROVIDER.add_span_processor(SimpleSpanProcessor(_EXPORTER))
 trace.set_tracer_provider(_PROVIDER)
 
 from src.x_twitter_mcp.tracing import (  # noqa: E402  (must come after provider install)
+    TraceContextMiddleware,
     TracingMiddleware,
     extract_traceparent_from_meta,
     parse_traceparent,
@@ -165,12 +167,20 @@ async def test_on_call_tool_records_exception(reset_exporter: InMemorySpanExport
 @pytest.mark.asyncio
 async def test_on_call_tool_propagates_traceparent(reset_exporter: InMemorySpanExporter):
     middleware = TracingMiddleware()
-    ctx = _make_context("get_user_profile", traceparent=VALID_TRACEPARENT)
+    # TracingMiddleware now reads from otel_context.get_current(); the HTTP
+    # layer (TraceContextMiddleware) is responsible for attaching the parent.
+    ctx = _make_context("get_user_profile", traceparent=None)
 
     async def call_next(_: Any) -> Any:
         return None
 
-    await middleware.on_call_tool(ctx, call_next)
+    # Simulate what TraceContextMiddleware does at the HTTP layer.
+    parent_ctx = restore_parent_context(VALID_TRACEPARENT)
+    token = otel_context.attach(parent_ctx)
+    try:
+        await middleware.on_call_tool(ctx, call_next)
+    finally:
+        otel_context.detach(token)
 
     spans = reset_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -180,3 +190,103 @@ async def test_on_call_tool_propagates_traceparent(reset_exporter: InMemorySpanE
     # Parent span ID matches the traceparent's span ID.
     assert span.parent is not None
     assert format(span.parent.span_id, "016x") == "b7ad6b7169203331"
+
+
+# ---------------------------------------------------------------------------
+# TraceContextMiddleware — ASGI-layer traceparent extraction
+# ---------------------------------------------------------------------------
+
+import json  # noqa: E402
+
+
+def _make_asgi_scope(headers: list[tuple[bytes, bytes]] | None = None) -> dict:
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": headers or [],
+        "query_string": b"",
+    }
+
+
+def _body_receive(body: bytes):
+    """Return an async receive callable that yields the given body once."""
+    consumed = False
+
+    async def receive():
+        nonlocal consumed
+        if not consumed:
+            consumed = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    return receive
+
+
+@pytest.mark.asyncio
+async def test_trace_context_middleware_extracts_from_body(
+    reset_exporter: InMemorySpanExporter,
+):
+    """TraceContextMiddleware restores parent context from JSON body _meta."""
+    captured_ctx: list[Any] = []
+
+    async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+        captured_ctx.append(otel_context.get_current())
+        # Consume the replayed body to confirm it is intact.
+        msg = await receive()
+        assert msg["body"] != b""
+
+    mw = TraceContextMiddleware(inner_app)
+    payload = {
+        "method": "tools/call",
+        "params": {
+            "name": "search_twitter",
+            "arguments": {},
+            "_meta": {"_otel_traceparent": VALID_TRACEPARENT},
+        },
+    }
+    body = json.dumps(payload).encode()
+    scope = _make_asgi_scope()
+    await mw(scope, _body_receive(body), None)
+
+    assert len(captured_ctx) == 1
+    span_ctx = trace.get_current_span(captured_ctx[0]).get_span_context()
+    assert format(span_ctx.trace_id, "032x") == "0af7651916cd43dd8448eb211c80319c"
+    assert format(span_ctx.span_id, "016x") == "b7ad6b7169203331"
+
+
+@pytest.mark.asyncio
+async def test_trace_context_middleware_extracts_from_header(
+    reset_exporter: InMemorySpanExporter,
+):
+    """TraceContextMiddleware falls back to W3C traceparent header."""
+    captured_ctx: list[Any] = []
+
+    async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+        captured_ctx.append(otel_context.get_current())
+
+    mw = TraceContextMiddleware(inner_app)
+    scope = _make_asgi_scope(
+        headers=[(b"traceparent", VALID_TRACEPARENT.encode())]
+    )
+    await mw(scope, _body_receive(b"{}"), None)
+
+    assert len(captured_ctx) == 1
+    span_ctx = trace.get_current_span(captured_ctx[0]).get_span_context()
+    assert format(span_ctx.trace_id, "032x") == "0af7651916cd43dd8448eb211c80319c"
+
+
+@pytest.mark.asyncio
+async def test_trace_context_middleware_passthrough_non_http(
+    reset_exporter: InMemorySpanExporter,
+):
+    """Non-HTTP scopes pass through without errors or OTel side effects."""
+    called: list[bool] = []
+
+    async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+        called.append(True)
+
+    mw = TraceContextMiddleware(inner_app)
+    scope = {"type": "websocket", "path": "/ws"}
+    await mw(scope, _body_receive(b""), None)
+    assert called == [True]

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -8,6 +8,7 @@ captures every span emitted by `mcp.<tool_name>`.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Any
 
@@ -294,3 +295,67 @@ async def test_trace_context_middleware_passthrough_non_http(
     scope = {"type": "websocket", "path": "/ws"}
     await mw(scope, _body_receive(b""), None)
     assert called == [True]
+
+
+@pytest.mark.asyncio
+async def test_trace_context_middleware_second_receive_does_not_force_disconnect(
+    reset_exporter: InMemorySpanExporter,
+):
+    """Regression: after the buffered body is replayed once, subsequent
+    ``receive()`` calls by the downstream app must NOT return an immediate
+    ``http.disconnect`` — they must delegate to the underlying receive callable.
+
+    FastMCP's streamable_http transport calls ``receive()`` a second time inside
+    its response handler to detect client disconnects mid-stream. The original
+    implementation hard-returned ``{"type": "http.disconnect"}`` on the second
+    call, causing FastMCP to abort the response before sending the final body
+    chunk. Uvicorn then logged ``ASGI callable returned without completing
+    response`` and Fly's proxy reported ``could not finish reading HTTP body
+    from instance``. Symptom: every MCP POST returned 200 but no body, so
+    Anthropic's Managed Agents saw ``MCP server 'x' initialize failed: protocol
+    error`` and aborted the session.
+    """
+    received_messages: list[dict[str, Any]] = []
+
+    # Simulate a real ASGI server: first receive yields the body, second
+    # receive blocks until cancelled (we never disconnect mid-test). The
+    # middleware must delegate to this for the second call, not short-circuit
+    # to http.disconnect.
+    body_yielded = False
+    disconnect_event = asyncio.Event()  # never set in this test
+
+    async def real_receive() -> dict[str, Any]:
+        nonlocal body_yielded
+        if not body_yielded:
+            body_yielded = True
+            return {"type": "http.request", "body": b"{}", "more_body": False}
+        # Block until disconnect fires (it never does in this test) — this is
+        # how a real ASGI server behaves after the body is drained.
+        await disconnect_event.wait()
+        return {"type": "http.disconnect"}
+
+    async def inner_app(scope: Any, receive: Any, send: Any) -> None:
+        # First call: get the body.
+        msg1 = await receive()
+        received_messages.append(msg1)
+        # Second call: would block in real life; we wrap in wait_for so the
+        # test fails fast if the middleware short-circuits to http.disconnect.
+        try:
+            msg2 = await asyncio.wait_for(receive(), timeout=0.1)
+            received_messages.append(msg2)
+        except asyncio.TimeoutError:
+            received_messages.append({"type": "blocked"})
+
+    mw = TraceContextMiddleware(inner_app)
+    scope = _make_asgi_scope()
+    await mw(scope, real_receive, None)
+
+    assert received_messages[0]["type"] == "http.request"
+    assert received_messages[0]["body"] == b"{}"
+    # CRITICAL: second receive must NOT be a synthetic http.disconnect.
+    # It must be "blocked" (delegated to real receive, which blocks).
+    assert received_messages[1]["type"] == "blocked", (
+        "TraceContextMiddleware must delegate second receive() to the real "
+        "receive callable so downstream apps see real disconnect events, not "
+        "a synthetic immediate disconnect. Got: %r" % received_messages[1]
+    )

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,182 @@
+"""Unit tests for src/x_twitter_mcp/tracing.py.
+
+Plan E.x Task 7B. We exercise the TracingMiddleware directly with a stub
+context + call_next rather than spinning up the full FastMCP server (which
+requires Twitter API creds at import time). The InMemorySpanExporter
+captures every span emitted by `mcp.<tool_name>`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
+
+# Install the test provider as the global BEFORE importing the tracing
+# module — OTel's SDK enforces `set_tracer_provider` once per process; any
+# later call (e.g. tracing.init_tracer_provider's no-op fallback) is a
+# silent no-op. Sharing one exporter across all tests is fine; we reset
+# captured spans at the start of each test via the autouse fixture.
+_EXPORTER = InMemorySpanExporter()
+_PROVIDER = TracerProvider(resource=Resource.create({"service.name": "x-mcp-test"}))
+_PROVIDER.add_span_processor(SimpleSpanProcessor(_EXPORTER))
+trace.set_tracer_provider(_PROVIDER)
+
+from src.x_twitter_mcp.tracing import (  # noqa: E402  (must come after provider install)
+    TracingMiddleware,
+    extract_traceparent_from_meta,
+    parse_traceparent,
+    restore_parent_context,
+)
+
+# Pin the tracing module's lazy-init singleton to our test provider so
+# get_tracer()'s `if _provider is None` short-circuits cleanly. Without
+# this, the module's first call would try to install a fresh provider and
+# the SDK would warn (the global is already set, so the second install is
+# a silent no-op — but the module's _provider stays None, repeating the
+# warning each time).
+import src.x_twitter_mcp.tracing as _tracing_mod  # noqa: E402
+
+_tracing_mod._provider = _PROVIDER  # type: ignore[attr-defined]
+
+VALID_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+
+
+@pytest.fixture(autouse=True)
+def reset_exporter():
+    """Clear captured spans before each test. Avoids cross-test bleed."""
+    _EXPORTER.clear()
+    yield _EXPORTER
+
+
+def test_parse_traceparent_valid():
+    ctx = parse_traceparent(VALID_TRACEPARENT)
+    assert ctx is not None
+    assert format(ctx.trace_id, "032x") == "0af7651916cd43dd8448eb211c80319c"
+    assert format(ctx.span_id, "016x") == "b7ad6b7169203331"
+    assert ctx.is_remote is True
+
+
+def test_parse_traceparent_invalid():
+    assert parse_traceparent(None) is None
+    assert parse_traceparent("") is None
+    assert parse_traceparent("malformed") is None
+
+
+def test_restore_parent_context_missing_returns_active():
+    # No traceparent → restored ctx == current active (which is empty here).
+    restored = restore_parent_context(None)
+    assert restored is not None  # smoke: returns a Context, not None
+
+
+@dataclass
+class _StubMeta:
+    """Mimics MCP RequestParams.Meta with `model_extra` for traceparent."""
+    model_extra: dict[str, Any]
+
+
+@dataclass
+class _StubMessage:
+    name: str
+    arguments: dict[str, Any]
+    meta: Any
+
+
+@dataclass
+class _StubContext:
+    message: _StubMessage
+    method: str = "tools/call"
+    type: str = "request"
+
+
+def _make_context(tool_name: str, traceparent: str | None) -> _StubContext:
+    meta = None
+    if traceparent is not None:
+        meta = _StubMeta(model_extra={"_otel_traceparent": traceparent})
+    return _StubContext(
+        message=_StubMessage(name=tool_name, arguments={}, meta=meta),
+    )
+
+
+def test_extract_traceparent_from_pydantic_extra():
+    meta = _StubMeta(model_extra={"_otel_traceparent": VALID_TRACEPARENT})
+    assert extract_traceparent_from_meta(meta) == VALID_TRACEPARENT
+
+
+def test_extract_traceparent_from_bare_dict():
+    assert extract_traceparent_from_meta({"_otel_traceparent": VALID_TRACEPARENT}) == VALID_TRACEPARENT
+
+
+def test_extract_traceparent_returns_none_for_missing():
+    assert extract_traceparent_from_meta(None) is None
+    assert extract_traceparent_from_meta(_StubMeta(model_extra={})) is None
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_emits_named_span(reset_exporter: InMemorySpanExporter):
+    middleware = TracingMiddleware()
+    ctx = _make_context("search_twitter", traceparent=None)
+    sentinel = object()
+
+    async def call_next(_: Any) -> Any:
+        return sentinel
+
+    result = await middleware.on_call_tool(ctx, call_next)
+    assert result is sentinel
+
+    spans = reset_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "mcp.search_twitter"
+    assert span.attributes["mcp.tool_name"] == "search_twitter"
+    assert span.attributes["gen_ai.system"] == "x-twitter"
+    assert span.status.status_code == StatusCode.OK
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_records_exception(reset_exporter: InMemorySpanExporter):
+    middleware = TracingMiddleware()
+    ctx = _make_context("post_tweet", traceparent=None)
+    boom = RuntimeError("Twitter API 503")
+
+    async def call_next(_: Any) -> Any:
+        raise boom
+
+    with pytest.raises(RuntimeError):
+        await middleware.on_call_tool(ctx, call_next)
+
+    spans = reset_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code == StatusCode.ERROR
+    # Exception is recorded as an event
+    assert any(event.name == "exception" for event in span.events)
+
+
+@pytest.mark.asyncio
+async def test_on_call_tool_propagates_traceparent(reset_exporter: InMemorySpanExporter):
+    middleware = TracingMiddleware()
+    ctx = _make_context("get_user_profile", traceparent=VALID_TRACEPARENT)
+
+    async def call_next(_: Any) -> Any:
+        return None
+
+    await middleware.on_call_tool(ctx, call_next)
+
+    spans = reset_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    # Trace ID restored from the injected traceparent.
+    assert format(span.context.trace_id, "032x") == "0af7651916cd43dd8448eb211c80319c"
+    # Parent span ID matches the traceparent's span ID.
+    assert span.parent is not None
+    assert format(span.parent.span_id, "016x") == "b7ad6b7169203331"

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -167,20 +167,24 @@ async def test_on_call_tool_records_exception(reset_exporter: InMemorySpanExport
 @pytest.mark.asyncio
 async def test_on_call_tool_propagates_traceparent(reset_exporter: InMemorySpanExporter):
     middleware = TracingMiddleware()
-    # TracingMiddleware now reads from otel_context.get_current(); the HTTP
-    # layer (TraceContextMiddleware) is responsible for attaching the parent.
+    # TracingMiddleware reads from the MCP SDK's request_ctx ContextVar.
+    # Simulate what the MCP SDK does inside the server task right before
+    # dispatching to the handler.
     ctx = _make_context("get_user_profile", traceparent=None)
 
     async def call_next(_: Any) -> Any:
         return None
 
-    # Simulate what TraceContextMiddleware does at the HTTP layer.
-    parent_ctx = restore_parent_context(VALID_TRACEPARENT)
-    token = otel_context.attach(parent_ctx)
+    from mcp.server.lowlevel.server import request_ctx as _mcp_request_ctx
+
+    class _MockRequestContext:
+        meta = _StubMeta(model_extra={"_otel_traceparent": VALID_TRACEPARENT})
+
+    token = _mcp_request_ctx.set(_MockRequestContext())
     try:
         await middleware.on_call_tool(ctx, call_next)
     finally:
-        otel_context.detach(token)
+        _mcp_request_ctx.reset(token)
 
     spans = reset_exporter.get_finished_spans()
     assert len(spans) == 1


### PR DESCRIPTION
## What
First PR-triggered CI for this repo (previously only `pypi_deploy.yaml`, which runs on release). Runs on `pull_request` and `push` to `main`:

- **test** — `pip install -e ".[dev]"` then `python -m pytest` (Python 3.11)
- **docker-build** — `docker build` of the Fly deploy image, no secrets

## Why
`main` had no build/test gate, so a broken state could go undetected until a manual `flyctl deploy`. The `docker build` job is the Fly analog of the wrangler dry-run that recently caught a missing dependency in the Telegram bridge.

## Also: a real undeclared-dependency fix
`tests/test_tracing.py` uses `@pytest.mark.asyncio`, but `pytest-asyncio` was never declared anywhere in the repo. A clean install ran **7 failed / 6 passed** (async tests unsupported). This PR declares it under `[project.optional-dependencies].dev` and sets `asyncio_mode = "auto"` — now **13/13 pass**. Same disease the CI exists to catch.

## Verification
`pip install -e ".[dev]" && python -m pytest` → 13 passed locally. The `docker build` job is verified by this PR's CI run (Docker wasn't available locally). No deploy step — Fly deploys stay manual.